### PR TITLE
Haptic feedback selecting bar graph hours

### DIFF
--- a/Campus Density/Cells/GraphCell.swift
+++ b/Campus Density/Cells/GraphCell.swift
@@ -27,6 +27,7 @@ class GraphCell: UICollectionViewCell {
     var selectedView: UIView!
     var axis: UIView!
     var bars = [UIView]()
+    var feedbackGenerator: UISelectionFeedbackGenerator?
 
     // MARK: - Constants
     let descriptionLabelHeight: CGFloat = 40
@@ -67,12 +68,15 @@ class GraphCell: UICollectionViewCell {
 
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let location = touches.first?.location(in: self) {
+            feedbackGenerator = UISelectionFeedbackGenerator()
+            feedbackGenerator?.prepare()
             respondToTouch(location: location)
         }
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         if let location = touches.first?.location(in: self) {
+            feedbackGenerator = nil
             let index = bars.firstIndex { bar -> Bool in
                 return bar.frame.contains(location)
             }
@@ -89,9 +93,12 @@ class GraphCell: UICollectionViewCell {
         }
         guard let barIndex = index else { return }
 
-        if !bars[barIndex].isHidden {
+        if !bars[barIndex].isHidden && selectedHour != bars[barIndex].tag {
 
             selectedHour = bars[barIndex].tag
+
+            feedbackGenerator?.selectionChanged()
+            feedbackGenerator?.prepare()
 
             descriptionLabelText = "\(getHourLabel(selectedHour: selectedHour)) - \(getCurrentDensity(densityMap: densityMap, selectedHour: selectedHour))"
             descriptionLabel.text = descriptionLabelText


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Added haptic feedback when selecting different bars in the bar graph that represents historical busyness/popular times. I thought it would feel nice but not sure if I should be adding things like this.

- [x] implemented haptic feedback for selecting different bars

### Test Plan <!-- Required -->

There are no screenshots for this because you feel it with the hand, not see it with the eyes

### Notes <!-- Optional -->

Perhaps could consider using this for different day of week selections as well. Not sure if it should be for both or just one of these things because it's also important not to overuse it or else the user could get distracted.
