### PR TITLE
Choose default meal filter based on current time and actual meal end time

### DIFF
--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -34,26 +34,26 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             menus = place.menus.weeksMenus[menuDay]
         }
         var meals = [Meal]()
+        var endTimes = [Int]()
         if (menus.menus.count != 0) {
             for meal in menus.menus {
                 if (meal.menu.count != 0) {
                     meals.append(Meal(rawValue: meal.description)!)
+                    endTimes.append(meal.endTime)
                 }
             }
             if !meals.contains(selectedMeal) && meals.count > 0 {
-                let date = Date()
-                let calendar = Calendar.current
-                let hour = calendar.component(.hour, from: date)
-                if (hour>=0 && hour<=12) {
-                    selectedMeal = meals[0]
-                } else if (hour>12 && hour<=16) {
-                    if meals.count==3 {
-                        selectedMeal = meals[1]
+                let currentTime = Int(Date().timeIntervalSince1970)
+                print("Current Time: \(currentTime)")
+                selectedMeal = meals[0]
+                for (index, endTime) in endTimes.enumerated() {
+                    if currentTime < endTime {
+                        print("\(currentTime) < \(endTime) at index \(index), which is \(meals[index]), choosing this")
+                        selectedMeal = meals[index]
+                        break
                     } else {
-                        selectedMeal = meals[0]
+                        print("\(currentTime) > \(endTime) at index \(index), which is \(meals[index])")
                     }
-                } else {
-                    selectedMeal = meals[-1]
                 }
             }
         }

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -11,6 +11,7 @@ import IGListKit
 import Firebase
 
 enum Meal: String {
+    case none = "No"
     case breakfast = "Breakfast"
     case brunch = "Brunch"
     case lunch = "Lunch"
@@ -23,7 +24,7 @@ class PlaceDetailViewController: UIViewController {
     var place: Place!
     var selectedWeekday: Int = 0
     var selectedHour: Int = 0
-    var selectedMeal: Meal = .breakfast
+    var selectedMeal: Meal = .none
     var weekdays = [Int]()
     var densityMap = [Int: Double]()
     var adapter: ListAdapter!


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Use the actual menu data start/end times to choose which filter to show by default for the menus. Chooses the first meal that has not ended yet, for example if dinner starts at 5 and ends at 8 and it's only 4 now (lunch is over) show the dinner menu. Maybe we should actually commit to master and use pull requests more.

- [x] fixed default meal filter selection

### Test Plan <!-- Required -->
<!-- Provide screenshots or point out the additional unit tests -->
Tested only for dinner today but I think it should work for others, at least it's an improvement over crashing