### PR TITLE
Better histogram scrolling, refresh animation

### DIFF
--- a/Campus Density/Cells/GraphCell.swift
+++ b/Campus Density/Cells/GraphCell.swift
@@ -97,8 +97,8 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         return abs(v.x) > abs(v.y)
     }
 
-    func didTapBar(bar: UIView) {
-        delegate?.graphCellDidSelectHour(selectedHour: bar.tag) // What this do?
+    func didSelectHour(selectedHour: Int) {
+        delegate?.graphCellDidSelectHour(selectedHour: selectedHour)
     }
 
     func respondToTouch(location: CGPoint) {
@@ -319,6 +319,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     }
 
     override func prepareForReuse() {
+        didSelectHour(selectedHour: selectedHour)
         for bar in bars {
             bar.removeFromSuperview()
         }

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -80,6 +80,10 @@ class PlaceDetailViewController: UIViewController {
 
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden = true
+    }
+
     func getHours() {
         API.hours(place: place) { [weak self] gotHours in
             if gotHours {

--- a/Campus Density/Views/LoadingBarsView.swift
+++ b/Campus Density/Views/LoadingBarsView.swift
@@ -112,7 +112,7 @@ class LoadingBarsView: UIView {
 
     func startAnimating() {
         animating = true
-        self.isHidden = false
+        alpha = 1
         rise(bar: barOne)
         rise(bar: barTwo)
         rise(bar: barThree)
@@ -122,7 +122,7 @@ class LoadingBarsView: UIView {
     func stopAnimating() {
         animating = false
         shouldLayout = [false, false, false, false]
-        self.isHidden = true
+        alpha = 0
     }
 
     func rise(bar: UIView) {
@@ -165,8 +165,22 @@ class LoadingBarsView: UIView {
         }
     }
 
+    func setHeight(bar: UIView, height: CGFloat) {
+        bar.snp.updateConstraints({ update in
+            update.height.equalTo(height)
+        })
+    }
+
     func randomHeight() -> CGFloat {
         return CGFloat(Float(arc4random()) / Float(UINT32_MAX)) * maxBarHeight
+    }
+
+    func setBarHeights(fraction: CGFloat) {
+        let height = fraction * maxBarHeight
+        setHeight(bar: barOne, height: height)
+        setHeight(bar: barTwo, height: height)
+        setHeight(bar: barThree, height: height)
+        setHeight(bar: barFour, height: height)
     }
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request improves the refresh experience on the main list of places, now pulling the list down makes the bars of the animation stretch until they are full and then starts playing the animation as the list is refreshing. Histogram scrolling from side to side is now a lot more fluid and predictable, doesn't matter how large the bar is anymore and it can capture vertical scrolling movements too. Also small fix to partially sliding back to the list of places from the detail view and cancelling it, previously the tab bar would remain.

- [x] implemented fancy histogram scrolly
- [x] made better refresh pully
- [x] fixed small tab bar disappearing buggy

### Test Plan <!-- Required -->
Good to play with
<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->
The refresh animation isn't perfect but that's due to the default one starting at the top and ours starting at the bottom so it always looks kinda weird