### PR TITLE
Hours cleanup and time zone support

### DIFF
--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -305,6 +305,8 @@ class API {
 
             let formatter = DateFormatter()
             formatter.dateFormat = "MM-dd-yy"
+            // Always get hours based on the time in New York
+            formatter.timeZone = TimeZone(identifier: "America/New_York")
             let startDate = formatter.string(from: today)
             let endDate = formatter.string(from: sixDaysLater)
 
@@ -326,6 +328,8 @@ class API {
                                 let day = dailyInfo.dayOfWeek
                                 let dailyHours = dailyInfo.dailyHours
                                 let timeFormatter = DateFormatter()
+                                // Display hours in ET
+                                timeFormatter.timeZone = TimeZone(identifier: "America/New_York")
                                 timeFormatter.timeStyle = .short
                                 guard let openTimestamp = dailyHours["startTimestamp"], let closeTimestamp = dailyHours["endTimestamp"] else { return }
                                 let open = Date(timeIntervalSince1970: openTimestamp)

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -322,9 +322,7 @@ class API {
                         case .success(let hoursResponseArray):
                             let hoursResponse = hoursResponseArray[0]
                             var hours = [Int: String]()
-                            var index: Int = 0
-                            while index < hoursResponse.hours.count {
-                                let dailyInfo = hoursResponse.hours[index]
+                            for dailyInfo in hoursResponse.hours {
                                 let day = dailyInfo.dayOfWeek
                                 let dailyHours = dailyInfo.dailyHours
                                 let timeFormatter = DateFormatter()
@@ -334,16 +332,11 @@ class API {
                                 let close = Date(timeIntervalSince1970: closeTimestamp)
                                 let openTime = timeFormatter.string(from: open)
                                 let closeTime = timeFormatter.string(from: close)
-                                let isLastIndex = index == hoursResponse.hours.count - 1
                                 if let hoursString = hours[day] {
-                                    hours[day] = hoursString + "\(openTime) - \(closeTime)"
+                                    hours[day] = hoursString + "\n\(openTime) - \(closeTime)"
                                 } else {
                                     hours[day] = "\(openTime) - \(closeTime)"
                                 }
-                                if let hoursString = hours[day], !isLastIndex {
-                                    hours[day] = hoursString + "\n"
-                                }
-                                index += 1
                             }
                             if let placeIndex = System.places.firstIndex(where: { other -> Bool in
                                 return other.id == place.id

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -300,23 +300,13 @@ class API {
 
         var success = true
 
-        let formatter = DateFormatter()
-        formatter.dateStyle = .short
         let today = Date()
         if let sixDaysLater = Calendar.current.date(byAdding: Calendar.Component.day, value: 6, to: today) {
 
-            let start = formatter.string(from: today)
-            let end = formatter.string(from: sixDaysLater)
-            let startComponents = start.components(separatedBy: "/")
-            let startYear = String(startComponents[2].suffix(2))
-            let startDay = startComponents[1].count == 1 ? "0\(startComponents[1])" : startComponents[1]
-            let startMonth = startComponents[0].count == 1 ? "0\(startComponents[0])" : startComponents[0]
-            let endComponents = end.components(separatedBy: "/")
-            let endYear = String(endComponents[2].suffix(2))
-            let endDay = endComponents[1].count == 1 ? "0\(endComponents[1])" : endComponents[1]
-            let endMonth = endComponents[0].count == 1 ? "0\(endComponents[0])" : endComponents[0]
-            let startDate = "\(startMonth)-\(startDay)-\(startYear)"
-            let endDate = "\(endMonth)-\(endDay)-\(endYear)"
+            let formatter = DateFormatter()
+            formatter.dateFormat = "MM-dd-yy"
+            let startDate = formatter.string(from: today)
+            let endDate = formatter.string(from: sixDaysLater)
 
             let parameters = [
                 "id": place.id,

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -40,6 +40,8 @@ class PlaceDetailViewController: UIViewController {
     let largeLoadingBarsLength: CGFloat = 63
     let linkTopOffset: CGFloat = 5
     let feedbackForm = "https://docs.google.com/forms/d/e/1FAIpQLSeJZ7AyVRZ8tfw-XiJqREmKn9y0wPCyreEkkysJn0QHCLDmaA/viewform?vc=0&c=0&w=1"
+    let ithacaTime = TimeZone(identifier: "America/New_York")!
+
     override func viewDidLoad() {
         super.viewDidLoad()
         print("\n")
@@ -198,7 +200,8 @@ class PlaceDetailViewController: UIViewController {
 
     func getCurrentHour() -> Int {
         let today = Date()
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.timeZone = ithacaTime
         return calendar.component(.hour, from: today)
     }
 
@@ -306,7 +309,8 @@ class PlaceDetailViewController: UIViewController {
 
     func getWeekday() -> Int {
         let today = Date()
-        let calendar = Calendar.current
+        var calendar = Calendar.current
+        calendar.timeZone = ithacaTime
         return calendar.component(.weekday, from: today) - 1
     }
 
@@ -336,11 +340,11 @@ class PlaceDetailViewController: UIViewController {
         guard let weekdayIndex = weekdays.firstIndex(of: selectedWeekday) else { return "" }
         guard let selectedDate = Calendar.current.date(byAdding: Calendar.Component.day, value: weekdayIndex, to: today) else { return "" }
         let formatter = DateFormatter()
-        formatter.timeStyle = .none
-        formatter.dateStyle = .long
-        let dateString = formatter.string(from: selectedDate)
-        let dateStringComponents = dateString.components(separatedBy: ",")
-        return dateStringComponents[0]
+        formatter.timeZone = ithacaTime
+        formatter.setLocalizedDateFormatFromTemplate("MMMM dd")
+        let text = formatter.string(from: selectedDate)
+          + ((TimeZone.current != ithacaTime) ? " (\(ithacaTime.abbreviation()!))" : "")
+        return text
     }
 
 }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds support for different user time zones and replaces some ugly manual date format extraction with built-in formatting methods. The app now displays menus, hours, and days of the week in Eastern Time instead of the user's local time since dining halls are physical locations in a static time zone. Also notifies that things are in ET if system time is different.

- [x] implemented time zone support
- [x] fixed #24 about extra newline
- [x] cleaned up yucky date formatting for API requests

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

<img width="585" alt="Screen Shot 2020-04-12 at 15 49 16" src="https://user-images.githubusercontent.com/22627336/79081016-cea53300-7cd6-11ea-9e6a-9e1a219a60bd.png">

Tested in Mountain Time (behind), Eastern Time, and in China (ahead) where it is April 13th (the next day).