### PR TITLE
Grey graph for no data/closed

### DIFF
--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -12,10 +12,7 @@ import IGListKit
 extension PlaceDetailViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        var description = "Closed"
-        if !densityMap.isEmpty {
-            description = "\(getHourLabel(selectedHour: selectedHour)) - \(getCurrentDensity(densityMap: densityMap, selectedHour: selectedHour))"
-        }
+        let description = GraphCell.descriptionLabelText(selectedHour: selectedHour, densityMap: densityMap)
         let weekday = getCurrentWeekday() == selectedWeekday ? "Today" : selectedWeekdayText()
         let date = selectedDateText()
         var hours = "No hours available"

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -12,7 +12,6 @@ import IGListKit
 extension PlaceDetailViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
-        let description = GraphCell.descriptionLabelText(selectedHour: selectedHour, densityMap: densityMap)
         let weekday = getCurrentWeekday() == selectedWeekday ? "Today" : selectedWeekdayText()
         let date = selectedDateText()
         var hours = "No hours available"
@@ -64,7 +63,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             SpaceModel(space: Constants.smallPadding),
             DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays),
             SpaceModel(space: Constants.mediumPadding),
-            GraphModel(description: description, densityMap: densityMap, selectedHour: selectedHour),
+            GraphModel(densityMap: densityMap, selectedHour: selectedHour),
             SpaceModel(space: Constants.mediumPadding),
             HoursHeaderModel(weekday: weekday, date: date),
             SpaceModel(space: Constants.smallPadding),

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -63,7 +63,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     }
 
     /// Returns the text description of density at a certain hour
-    static func descriptionLabelText(selectedHour: Int, densityMap: [Int: Double]) -> String {
+    func descriptionLabelText(selectedHour: Int, densityMap: [Int: Double]) -> String {
         return "\(getHourLabel(selectedHour: selectedHour)) - \(getCurrentDensity(densityMap: densityMap, selectedHour: selectedHour))"
     }
 
@@ -118,7 +118,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
             feedbackGenerator.selectionChanged()
             feedbackGenerator.prepare()
 
-            descriptionLabelText = GraphCell.descriptionLabelText(selectedHour: selectedHour, densityMap: densityMap)
+            descriptionLabelText = descriptionLabelText(selectedHour: selectedHour, densityMap: densityMap)
             descriptionLabel.text = descriptionLabelText
 
             setupConstraints()
@@ -285,12 +285,12 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         selectedView.snp.removeConstraints()
     }
 
-    func configure(description: String, densityMap: [Int: Double], selectedHour: Int, delegate: GraphCellDelegate) {
-        self.descriptionLabelText = description
-        descriptionLabel.text = description
+    func configure(densityMap: [Int: Double], selectedHour: Int, delegate: GraphCellDelegate) {
         self.selectedHour = selectedHour
         self.delegate = delegate
         self.densityMap = densityMap
+        descriptionLabelText = descriptionLabelText(selectedHour: selectedHour, densityMap: densityMap)
+        descriptionLabel.text = descriptionLabelText
         let numBars = CGFloat(end - start + 3)
         let barWidth: CGFloat = (frame.width - Constants.smallPadding * 2) / numBars
         layoutBars(barWidth: barWidth)

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -223,24 +223,10 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
             bar.tag = startHour
             var barHeight: CGFloat = 1
             if let historicalAverage = densityMap[startHour] {
-                if historicalAverage < 0.25 {
-                    bar.backgroundColor = .lightTeal
-                } else if historicalAverage < 0.5 {
-                    bar.backgroundColor = .wheat
-                } else if historicalAverage < 0.85 {
-                    bar.backgroundColor = .peach
-                } else {
-                    bar.backgroundColor = .orangeyRed
-                }
+                bar.configureOpen(historicalAverage: historicalAverage)
                 barHeight = maxBarHeight * CGFloat(historicalAverage < 0.075 ? 0.075 : historicalAverage) // Minimum bar height of 0.075
-                bar.clipsToBounds = true
-                bar.layer.cornerRadius = 5
-                bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-                bar.layer.borderColor = UIColor.white.cgColor
-                bar.layer.borderWidth = 0.5
             } else {
-                bar.isClosedTime = true
-                bar.backgroundColor = .whiteTwo
+                bar.configureClosed()
                 barHeight = maxBarHeight
             }
             addSubview(bar)
@@ -317,5 +303,27 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
 class BarView: UIView {
 
     var isClosedTime: Bool = false
+
+    func configureOpen(historicalAverage: Double) {
+        if historicalAverage < 0.25 {
+            backgroundColor = .lightTeal
+        } else if historicalAverage < 0.5 {
+            backgroundColor = .wheat
+        } else if historicalAverage < 0.85 {
+            backgroundColor = .peach
+        } else {
+            backgroundColor = .orangeyRed
+        }
+        clipsToBounds = true
+        layer.cornerRadius = 5
+        layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        layer.borderColor = UIColor.white.cgColor
+        layer.borderWidth = 0.5
+    }
+
+    func configureClosed() {
+        isClosedTime = true
+        backgroundColor = .whiteTwo
+    }
 
 }

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -34,7 +34,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     let maxBarHeight: CGFloat = 150
     let axisLabelVerticalPadding: CGFloat = 10
     let axisLabelHeight: CGFloat = 15
-    let axisHeight: CGFloat = 2
+    let axisHeight: CGFloat = 1
     let start: Int = 7
     let end: Int = 23
     let horizontalPadding: CGFloat = 15
@@ -140,7 +140,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         addSubview(descriptionLabel)
 
         axis = UIView()
-        axis.backgroundColor = .whiteTwo
+        axis.backgroundColor = .warmGray
         axis.clipsToBounds = true
         axis.layer.cornerRadius = axisHeight / 2
         addSubview(axis)
@@ -166,7 +166,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
             let tick = UIView()
             tick.clipsToBounds = true
             tick.layer.cornerRadius = axisHeight / 2
-            tick.backgroundColor = .whiteTwo
+            tick.backgroundColor = .warmGray
             addSubview(tick)
 
             let shouldLabel = (endHour - startHour) % numTicks == 0
@@ -202,7 +202,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         let lastTick = UIView()
         lastTick.clipsToBounds = true
         lastTick.layer.cornerRadius = axisHeight / 2
-        lastTick.backgroundColor = .whiteTwo
+        lastTick.backgroundColor = .warmGray
         addSubview(lastTick)
 
         lastTick.snp.makeConstraints { make in

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -243,14 +243,15 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
                     bar.backgroundColor = .orangeyRed
                 }
                 barHeight = maxBarHeight * CGFloat(historicalAverage < 0.075 ? 0.075 : historicalAverage)
+                bar.clipsToBounds = true
+                bar.layer.cornerRadius = 5
+                bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+                bar.layer.borderColor = UIColor.white.cgColor
+                bar.layer.borderWidth = 0.5
             } else {
-                bar.isHidden = true
+                bar.backgroundColor = .whiteTwo
+                barHeight = maxBarHeight
             }
-            bar.clipsToBounds = true
-            bar.layer.cornerRadius = 5
-            bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-            bar.layer.borderColor = UIColor.white.cgColor
-            bar.layer.borderWidth = 0.5
             addSubview(bar)
 
             bar.snp.makeConstraints { make in

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -26,12 +26,12 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     var descriptionLabel: UILabel!
     var selectedView: UIView!
     var axis: UIView!
-    var bars = [UIView]()
+    var bars = [BarView]()
     var feedbackGenerator = UISelectionFeedbackGenerator()
 
     // MARK: - Constants
     let descriptionLabelHeight: CGFloat = 40
-    let descriptionLabelVerticalPadding: CGFloat = 50
+    let descriptionLabelVerticalPadding: CGFloat = 0
     let descriptionLabelHorizontalPadding: CGFloat = 15
     let maxBarHeight: CGFloat = 150
     let axisLabelVerticalPadding: CGFloat = 10
@@ -130,7 +130,12 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
             selectedView.snp.remakeConstraints { update in
                 update.width.equalTo(selectedViewWidth)
                 update.top.equalTo(descriptionLabel.snp.bottom)
-                update.bottom.equalTo(bars[barIndex].snp.top)
+                if bars[barIndex].isClosedTime {
+                    selectedView.superview?.bringSubviewToFront(selectedView)
+                    update.bottom.equalTo(bars[barIndex].snp.bottom)
+                } else {
+                    update.bottom.equalTo(bars[barIndex].snp.top)
+                }
                 update.centerX.equalTo(bars[barIndex])
             }
 
@@ -229,7 +234,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         let endHour: Int = end
         var barLeftOffset: CGFloat = barWidth
         while startHour <= endHour {
-            let bar = UIView()
+            let bar = BarView()
             bar.tag = startHour
             var barHeight: CGFloat = 1
             if let historicalAverage = densityMap[startHour] {
@@ -237,18 +242,19 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
                     bar.backgroundColor = .lightTeal
                 } else if historicalAverage < 0.5 {
                     bar.backgroundColor = .wheat
-                } else if historicalAverage < 0.75 {
+                } else if historicalAverage < 0.85 {
                     bar.backgroundColor = .peach
                 } else {
                     bar.backgroundColor = .orangeyRed
                 }
-                barHeight = maxBarHeight * CGFloat(historicalAverage < 0.075 ? 0.075 : historicalAverage)
+                barHeight = maxBarHeight * CGFloat(historicalAverage < 0.075 ? 0.075 : historicalAverage) // Minimum bar height of 0.075
                 bar.clipsToBounds = true
                 bar.layer.cornerRadius = 5
                 bar.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
                 bar.layer.borderColor = UIColor.white.cgColor
                 bar.layer.borderWidth = 0.5
             } else {
+                bar.isClosedTime = true
                 bar.backgroundColor = .whiteTwo
                 barHeight = maxBarHeight
             }
@@ -337,5 +343,11 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         self.densityMap = densityMap
         setupConstraints()
     }
+
+}
+
+class BarView: UIView {
+
+    var isClosedTime: Bool = false
 
 }

--- a/Campus Density/DiningCells/GraphCell.swift
+++ b/Campus Density/DiningCells/GraphCell.swift
@@ -31,8 +31,6 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
 
     // MARK: - Constants
     let descriptionLabelHeight: CGFloat = 40
-    let descriptionLabelVerticalPadding: CGFloat = 0
-    let descriptionLabelHorizontalPadding: CGFloat = 15
     let maxBarHeight: CGFloat = 150
     let axisLabelVerticalPadding: CGFloat = 10
     let axisLabelHeight: CGFloat = 15
@@ -45,7 +43,8 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
     let numTicks: Int = 3
     let smallTickHeight: CGFloat = 5
     let largeTickHeight: CGFloat = 10
-    let barGraphViewVerticalPadding: CGFloat = 50
+    let barToLabelGap: CGFloat = Constants.largePadding
+    let greyBarExtraHeight: CGFloat = Constants.largePadding / 2
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -156,7 +155,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
         axis.snp.makeConstraints { make in
             make.width.equalToSuperview().inset(Constants.smallPadding)
             make.height.equalTo(axisHeight)
-            make.top.equalTo(descriptionLabelHeight + Constants.largePadding + maxBarHeight)
+            make.top.equalTo(maxBarHeight + barToLabelGap + descriptionLabelHeight)
             make.centerX.equalToSuperview()
         }
 
@@ -227,7 +226,7 @@ class GraphCell: UICollectionViewCell, UIGestureRecognizerDelegate {
                 barHeight = maxBarHeight * CGFloat(historicalAverage < 0.075 ? 0.075 : historicalAverage) // Minimum bar height of 0.075
             } else {
                 bar.configureClosed()
-                barHeight = maxBarHeight
+                barHeight = maxBarHeight + greyBarExtraHeight
             }
             addSubview(bar)
 

--- a/Campus Density/DiningModels/GraphModel.swift
+++ b/Campus Density/DiningModels/GraphModel.swift
@@ -11,13 +11,11 @@ import IGListKit
 
 class GraphModel {
 
-    var description: String
     var densityMap: [Int: Double]
     var selectedHour: Int
     let identifier = UUID().uuidString
 
-    init(description: String, densityMap: [Int: Double], selectedHour: Int) {
-        self.description = description
+    init(densityMap: [Int: Double], selectedHour: Int) {
         self.densityMap = densityMap
         self.selectedHour = selectedHour
     }

--- a/Campus Density/SectionControllers/GraphSectionController.swift
+++ b/Campus Density/SectionControllers/GraphSectionController.swift
@@ -36,7 +36,7 @@ class GraphSectionController: ListSectionController {
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: GraphCell.self, for: self, at: index) as! GraphCell
-        cell.configure(description: graphModel.description, densityMap: graphModel.densityMap, selectedHour: graphModel.selectedHour, delegate: self)
+        cell.configure(densityMap: graphModel.densityMap, selectedHour: graphModel.selectedHour, delegate: self)
         return cell
     }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request greys out bar hours for which there is no historical density data and standardizes graph behavior for when the facility is closed. With the change in what data is returned for historical requests on the back end, this should grey out graph hours that are not open on a particular day. The graph axis has also been tweaked to provide better contrast.

- [x] Added greyed out graph sections
- [x] Standardized graph behavior for when there is no data
- [x] Extracted out bar appearance configuration and removed redundant code
- [x] Fixed orange -> red limit from 0.75 to 0.85

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Appel is open when there are colored bars and closed when the hour positions are greyed out
<img width="573" alt="Screen Shot 2020-06-21 at 18 10 28" src="https://user-images.githubusercontent.com/22627336/85238562-007bf980-b3ec-11ea-9739-5abdd6c46ae2.png">

In this case, there is no historical data for Okenshields on Sundays and the dining hall is closed. Previously, "closed" would just appear centered in the middle of the graph. Change was made to be more in line with how regular days are displayed
<img width="573" alt="Screen Shot 2020-06-21 at 18 10 57" src="https://user-images.githubusercontent.com/22627336/85238556-f35f0a80-b3eb-11ea-8ded-7294ec1a67e7.png">
