### PR TITLE
Last updated text

### DIFF
--- a/Campus Density.xcodeproj/project.pbxproj
+++ b/Campus Density.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		3C873289244218CA00D42F59 /* GraphHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C873288244218CA00D42F59 /* GraphHeaderCell.swift */; };
 		3C87328B244218EE00D42F59 /* GraphHeaderSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87328A244218EE00D42F59 /* GraphHeaderSectionController.swift */; };
 		3C87328D244219B000D42F59 /* GraphHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87328C244219B000D42F59 /* GraphHeaderModel.swift */; };
+		3CBCB12924A7C6B600543B3D /* LastUpdatedTextModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCB12824A7C6B600543B3D /* LastUpdatedTextModel.swift */; };
+		3CBCB12B24A7C73000543B3D /* LastUpdatedTextSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCB12A24A7C73000543B3D /* LastUpdatedTextSectionController.swift */; };
 		69FBE3A7C9A2FABCC58E8B38 /* Pods_Campus_DensityTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D1B0CC1499D677A1BC9D1C8 /* Pods_Campus_DensityTests.framework */; };
 		85FDD1AC6EB4680031023AA8 /* Pods_Campus_DensityUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FE409273BF25EA7FB45E355 /* Pods_Campus_DensityUITests.framework */; };
 		EE03ED9123EBDA800064266B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = EE03ED8F23EBDA800064266B /* GoogleService-Info.plist */; };
@@ -156,6 +158,8 @@
 		3C873288244218CA00D42F59 /* GraphHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderCell.swift; sourceTree = "<group>"; };
 		3C87328A244218EE00D42F59 /* GraphHeaderSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderSectionController.swift; sourceTree = "<group>"; };
 		3C87328C244219B000D42F59 /* GraphHeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderModel.swift; sourceTree = "<group>"; };
+		3CBCB12824A7C6B600543B3D /* LastUpdatedTextModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdatedTextModel.swift; sourceTree = "<group>"; };
+		3CBCB12A24A7C73000543B3D /* LastUpdatedTextSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdatedTextSectionController.swift; sourceTree = "<group>"; };
 		4161DBCCBFDC9BA3D5E85BF0 /* Pods-Campus DensityTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Campus DensityTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Campus DensityTests/Pods-Campus DensityTests.release.xcconfig"; sourceTree = "<group>"; };
 		4D1B0CC1499D677A1BC9D1C8 /* Pods_Campus_DensityTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Campus_DensityTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FE409273BF25EA7FB45E355 /* Pods_Campus_DensityUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Campus_DensityUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -164,7 +168,7 @@
 		B792838E50BEC810AD8F4BF1 /* Pods-Campus DensityTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Campus DensityTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Campus DensityTests/Pods-Campus DensityTests.debug.xcconfig"; sourceTree = "<group>"; };
 		EE03ED8F23EBDA800064266B /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Secrets/GoogleService-Info.plist"; sourceTree = SOURCE_ROOT; };
 		EE03ED9023EBDA800064266B /* Keys.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Keys.plist; path = Secrets/Keys.plist; sourceTree = SOURCE_ROOT; };
-		EE1BC55F24954238004DD427 /* AvailabilityInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AvailabilityInfoCell.swift; path = AvailabilityInfoCell.swift; sourceTree = "<group>"; };
+		EE1BC55F24954238004DD427 /* AvailabilityInfoCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityInfoCell.swift; sourceTree = "<group>"; };
 		EE1BC56124967C8A004DD427 /* AvailabilityInfoSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityInfoSectionController.swift; sourceTree = "<group>"; };
 		EE1BC56324967CF4004DD427 /* AvailabilityInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityInfoModel.swift; sourceTree = "<group>"; };
 		EE1BC56524969B28004DD427 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -237,6 +241,7 @@
 				3C87328C244219B000D42F59 /* GraphHeaderModel.swift */,
 				EE1BC56324967CF4004DD427 /* AvailabilityInfoModel.swift */,
 				EEA4117E249E849100190A30 /* AvailabilityHeaderModel.swift */,
+				3CBCB12824A7C6B600543B3D /* LastUpdatedTextModel.swift */,
 			);
 			path = DiningModels;
 			sourceTree = "<group>";
@@ -259,6 +264,7 @@
 				3C87328A244218EE00D42F59 /* GraphHeaderSectionController.swift */,
 				EE1BC56124967C8A004DD427 /* AvailabilityInfoSectionController.swift */,
 				EEA41180249E85C700190A30 /* AvailabilityHeaderSectionController.swift */,
+				3CBCB12A24A7C73000543B3D /* LastUpdatedTextSectionController.swift */,
 			);
 			path = SectionControllers;
 			sourceTree = "<group>";
@@ -627,6 +633,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C8B6D7422324FFA00058AE6 /* CurrentDensityCell.swift in Sources */,
+				3CBCB12B24A7C73000543B3D /* LastUpdatedTextSectionController.swift in Sources */,
 				EE93BF182380A44300219902 /* MealFilterCell.swift in Sources */,
 				0CB3BF7A2232C0F700A5B371 /* DaySelectionCell.swift in Sources */,
 				0C29A760219E1F4200515D01 /* API.swift in Sources */,
@@ -668,6 +675,7 @@
 				0C209B1B22482DDB0007AFA9 /* FiltersSectionController.swift in Sources */,
 				EE1BC56024954239004DD427 /* AvailabilityInfoCell.swift in Sources */,
 				0CB3BF822232CC1E00A5B371 /* HoursHeaderCell.swift in Sources */,
+				3CBCB12924A7C6B600543B3D /* LastUpdatedTextModel.swift in Sources */,
 				0C209B17224829280007AFA9 /* LogoCell.swift in Sources */,
 				0C5D0C0B21827F9C00060874 /* UIFont+Extension.swift in Sources */,
 				0C8B6D612232441C00058AE6 /* CurrentDensityModel.swift in Sources */,

--- a/Campus Density.xcodeproj/project.pbxproj
+++ b/Campus Density.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		3C87328D244219B000D42F59 /* GraphHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87328C244219B000D42F59 /* GraphHeaderModel.swift */; };
 		3CBCB12924A7C6B600543B3D /* LastUpdatedTextModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCB12824A7C6B600543B3D /* LastUpdatedTextModel.swift */; };
 		3CBCB12B24A7C73000543B3D /* LastUpdatedTextSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CBCB12A24A7C73000543B3D /* LastUpdatedTextSectionController.swift */; };
+		3CD56C8D24AEB21A004D4910 /* LastUpdatedTextCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CD56C8C24AEB21A004D4910 /* LastUpdatedTextCell.swift */; };
 		69FBE3A7C9A2FABCC58E8B38 /* Pods_Campus_DensityTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D1B0CC1499D677A1BC9D1C8 /* Pods_Campus_DensityTests.framework */; };
 		85FDD1AC6EB4680031023AA8 /* Pods_Campus_DensityUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4FE409273BF25EA7FB45E355 /* Pods_Campus_DensityUITests.framework */; };
 		EE03ED9123EBDA800064266B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = EE03ED8F23EBDA800064266B /* GoogleService-Info.plist */; };
@@ -160,6 +161,7 @@
 		3C87328C244219B000D42F59 /* GraphHeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderModel.swift; sourceTree = "<group>"; };
 		3CBCB12824A7C6B600543B3D /* LastUpdatedTextModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdatedTextModel.swift; sourceTree = "<group>"; };
 		3CBCB12A24A7C73000543B3D /* LastUpdatedTextSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdatedTextSectionController.swift; sourceTree = "<group>"; };
+		3CD56C8C24AEB21A004D4910 /* LastUpdatedTextCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastUpdatedTextCell.swift; sourceTree = "<group>"; };
 		4161DBCCBFDC9BA3D5E85BF0 /* Pods-Campus DensityTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Campus DensityTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Campus DensityTests/Pods-Campus DensityTests.release.xcconfig"; sourceTree = "<group>"; };
 		4D1B0CC1499D677A1BC9D1C8 /* Pods_Campus_DensityTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Campus_DensityTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4FE409273BF25EA7FB45E355 /* Pods_Campus_DensityUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Campus_DensityUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -345,6 +347,7 @@
 				3C8008E8240B3EAF004DD1DB /* MenuInteriorCell.swift */,
 				3C873288244218CA00D42F59 /* GraphHeaderCell.swift */,
 				EEA4117C249E841200190A30 /* AvailabilityHeaderCell.swift */,
+				3CD56C8C24AEB21A004D4910 /* LastUpdatedTextCell.swift */,
 			);
 			path = DiningCells;
 			sourceTree = "<group>";
@@ -660,6 +663,7 @@
 				EEA307C1238B28F400566BF7 /* GymsViewController.swift in Sources */,
 				EEED3D2B23F87752000E0220 /* GymDetailViewController.swift in Sources */,
 				0CB3BF782232BF3200A5B371 /* DaySelectionSectionController.swift in Sources */,
+				3CD56C8D24AEB21A004D4910 /* LastUpdatedTextCell.swift in Sources */,
 				EE1BC56224967C8A004DD427 /* AvailabilityInfoSectionController.swift in Sources */,
 				0C8B6D6B22324B8000058AE6 /* HoursModel.swift in Sources */,
 				0C8B6D63223244B700058AE6 /* FormLinkModel.swift in Sources */,

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -394,46 +394,6 @@ class API {
         return Date(timeIntervalSince1970: multiples * seconds)
     }
 
-    static func convertToMenuString(menudata: DayMenus) -> NSMutableAttributedString {
-        let menus = menudata.menus
-        let newLine = NSAttributedString(string: "\n")
-        let resultString = NSMutableAttributedString(string: "")
-        for menu in menus {
-            let desc = NSMutableAttributedString(string: menu.description)
-            desc.addAttribute(NSAttributedString.Key.foregroundColor, value: UIColor.grayishBrown, range: desc.mutableString.range(of: menu.description))
-            desc.addAttribute(NSAttributedString.Key.font, value: UIFont.eighteenBold, range: desc.mutableString.range(of: menu.description))
-            let menuitemlist = menu.menu
-            if (menuitemlist.count != 0) {
-                resultString.append(desc)
-                resultString.append(newLine)
-            }
-            for menuitem in menuitemlist {
-                for item in menuitem.items {
-                    let itemNS = NSAttributedString(string: item)
-                    resultString.append(itemNS)
-                    resultString.append(newLine)
-                }
-            }
-            if (menuitemlist.count != 0) {
-                resultString.append(newLine)
-            }
-        }
-
-        return resultString
-    }
-
-    static func convertToDict(menudata: DayMenus) -> [String: [String: [String]]] {
-        let menus = menudata.menus
-        var res = [String: [String: [String]]]()
-        for menu in menus {
-            res[menu.description] = [String: [String]]()
-            for station in menu.menu {
-                res[menu.description]?[station.category] = station.items
-            }
-        }
-        return res
-    }
-
     static func menus(place: Place, completion: @escaping (Bool) -> Void) {
         guard let token = System.token else { return }
         let headers: HTTPHeaders = [

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -188,6 +188,8 @@ struct WeekMenus: Codable {
 
 class API {
 
+    static var lastUpdatedDensityTime: Date?
+
     //sets up the base url for fetching data
     static var url: String {
         guard let path = Bundle.main.path(forResource: "Keys", ofType: "plist"), let dict = NSDictionary(contentsOfFile: path) else { return "" }
@@ -371,6 +373,7 @@ class API {
                 let result: Result<[PlaceDensity]> = decoder.decodeResponse(from: response)
                 switch result {
                 case .success(let densities):
+                    self.lastUpdatedDensityTime = Date() // Set last updated density time to now
                     densities.forEach({ placeDensity in
                         let index = System.places.firstIndex(where: { place -> Bool in
                             return place.id == placeDensity.id
@@ -384,6 +387,11 @@ class API {
                     completion(false)
                 }
         }
+    }
+
+    static func lastUpdatedDensityTimeRounded(seconds: Double) -> Date {
+        let multiples = floor(lastUpdatedDensityTime!.timeIntervalSince1970 / seconds)
+        return Date(timeIntervalSince1970: multiples * seconds)
     }
 
     static func convertToMenuString(menudata: DayMenus) -> NSMutableAttributedString {

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -188,7 +188,9 @@ struct WeekMenus: Codable {
 
 class API {
 
+    /// API remembering when it last updated density
     static var lastUpdatedDensityTime: Date?
+    static let lastUpdatedRoundingSeconds: Double = 300
 
     //sets up the base url for fetching data
     static var url: String {
@@ -389,9 +391,9 @@ class API {
         }
     }
 
-    static func lastUpdatedDensityTimeRounded(seconds: Double) -> Date {
-        let multiples = floor(lastUpdatedDensityTime!.timeIntervalSince1970 / seconds)
-        return Date(timeIntervalSince1970: multiples * seconds)
+    static func getLastUpdatedDensityTime() -> Date {
+        let multiples = floor(lastUpdatedDensityTime!.timeIntervalSince1970 / lastUpdatedRoundingSeconds)
+        return Date(timeIntervalSince1970: multiples * lastUpdatedRoundingSeconds)
     }
 
     static func menus(place: Place, completion: @escaping (Bool) -> Void) {

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -14,7 +14,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         let weekday = getCurrentWeekday() == selectedWeekday ? "Today" : selectedWeekdayText()
         let date = selectedDateText()
-        let lastUpdatedTime = Date().roundedToSince1970(seconds: 300)
+        let lastUpdatedTime = API.lastUpdatedDensityTimeRounded(seconds: 300)
         var hours = "No hours available"
         var menus = DayMenus(menus: [], date: "help")
         if let selectedWeekdayHours = place.hours[selectedWeekday] {

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -14,6 +14,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         let weekday = getCurrentWeekday() == selectedWeekday ? "Today" : selectedWeekdayText()
         let date = selectedDateText()
+        let lastUpdatedTime = Date().roundedToSince1970(seconds: 300)
         var hours = "No hours available"
         var menus = DayMenus(menus: [], date: "help")
         if let selectedWeekdayHours = place.hours[selectedWeekday] {
@@ -59,7 +60,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             SpaceModel(space: Constants.smallPadding),
             AvailabilityInfoModel(place: place),
             SpaceModel(space: linkTopOffset),
-            FormLinkModel(feedbackForm: feedbackForm),
+            FormLinkModel(feedbackForm: feedbackForm, lastUpdated: lastUpdatedTime),
             SpaceModel(space: Constants.smallPadding),
             GraphHeaderModel(),
             SpaceModel(space: Constants.smallPadding),

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -14,7 +14,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         let weekday = getCurrentWeekday() == selectedWeekday ? "Today" : selectedWeekdayText()
         let date = selectedDateText()
-        let lastUpdatedTime = API.lastUpdatedDensityTimeRounded(seconds: 300)
+        let lastUpdatedTime = API.getLastUpdatedDensityTime()
         var hours = "No hours available"
         var menus = DayMenus(menus: [], date: "help")
         if let selectedWeekdayHours = place.hours[selectedWeekday] {

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -13,7 +13,7 @@ extension PlacesViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         if collectionView.isHidden { return [] }
-        let lastUpdatedTime = Date().roundedToSince1970(seconds: 300)
+        let lastUpdatedTime = API.lastUpdatedDensityTimeRounded(seconds: 300)
         var objects = [ListDiffable]()
         objects.append(FiltersModel(filters: filters, selectedFilter: selectedFilter))
         objects.append(contentsOf: filteredPlaces)
@@ -47,15 +47,6 @@ extension PlacesViewController: ListAdapterDataSource {
 
     func emptyView(for listAdapter: ListAdapter) -> UIView? {
         return nil
-    }
-
-}
-
-extension Date {
-
-    func roundedToSince1970(seconds: Double) -> Date {
-        let multiples = floor(self.timeIntervalSince1970 / seconds)
-        return Date(timeIntervalSince1970: multiples * seconds)
     }
 
 }

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -9,57 +9,6 @@
 import UIKit
 import IGListKit
 
-extension Filter: Equatable {
-    public static func == (lhs: Filter, rhs: Filter) -> Bool {
-        switch lhs {
-            case .all:
-                switch rhs {
-                    case .all:
-                        return true
-                    case .central:
-                        return false
-                    case .north:
-                        return false
-                    case .west:
-                        return false
-                }
-            case .central:
-                switch rhs {
-                    case .all:
-                        return false
-                    case .central:
-                        return true
-                    case .north:
-                        return false
-                    case .west:
-                        return false
-                }
-            case .north:
-                switch rhs {
-                    case .all:
-                        return false
-                    case .central:
-                        return false
-                    case .north:
-                        return true
-                    case .west:
-                        return false
-                }
-            case .west:
-                switch rhs {
-                    case .all:
-                        return false
-                    case .central:
-                        return false
-                    case .north:
-                        return false
-                    case .west:
-                        return true
-                }
-            }
-    }
-}
-
 extension PlacesViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -13,9 +13,12 @@ extension PlacesViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         if collectionView.isHidden { return [] }
+        let lastUpdatedTime = Date().roundedToSince1970(seconds: 300)
         var objects = [ListDiffable]()
         objects.append(FiltersModel(filters: filters, selectedFilter: selectedFilter))
         objects.append(contentsOf: filteredPlaces)
+        objects.append(SpaceModel(space: Constants.smallPadding))
+        objects.append(LastUpdatedTextModel(lastUpdated: lastUpdatedTime))
         objects.append(SpaceModel(space: Constants.smallPadding))
         objects.append(LogoModel(length: logoLength, link: dtiWebsite))
         objects.append(SpaceModel(space: Constants.smallPadding))
@@ -32,6 +35,9 @@ extension PlacesViewController: ListAdapterDataSource {
         } else if object is FiltersModel {
             let filtersModel = object as! FiltersModel
             return FiltersSectionController(filtersModel: filtersModel, delegate: self)
+        } else if object is LastUpdatedTextModel {
+            let lastUpdatedTextModel = object as! LastUpdatedTextModel
+            return LastUpdatedTextSectionController(lastUpdatedTextModel: lastUpdatedTextModel)
         } else if object is LogoModel {
             let logoModel = object as! LogoModel
             return LogoSectionController(logoModel: logoModel, delegate: self)
@@ -47,9 +53,9 @@ extension PlacesViewController: ListAdapterDataSource {
 
 extension Date {
 
-    func roundedTo(seconds: Double) -> Date {
-        let multiples = Int(self.timeIntervalSince1970 / seconds)
-        return Date(timeIntervalSince1970: Double(multiples) * seconds)
+    func roundedToSince1970(seconds: Double) -> Date {
+        let multiples = floor(self.timeIntervalSince1970 / seconds)
+        return Date(timeIntervalSince1970: multiples * seconds)
     }
 
 }

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -13,7 +13,7 @@ extension PlacesViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         if collectionView.isHidden { return [] }
-        let lastUpdatedTime = API.lastUpdatedDensityTimeRounded(seconds: 300)
+        let lastUpdatedTime = API.getLastUpdatedDensityTime()
         var objects = [ListDiffable]()
         objects.append(FiltersModel(filters: filters, selectedFilter: selectedFilter))
         objects.append(contentsOf: filteredPlaces)

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -45,6 +45,15 @@ extension PlacesViewController: ListAdapterDataSource {
 
 }
 
+extension Date {
+
+    func roundedTo(seconds: Double) -> Date {
+        let multiples = Int(self.timeIntervalSince1970 / seconds)
+        return Date(timeIntervalSince1970: Double(multiples) * seconds)
+    }
+
+}
+
 extension PlacesViewController: FiltersSectionControllerDelegate {
 
     func filtersSectionControllerDidSelectFilter(selectedFilter: Filter) {

--- a/Campus Density/Controllers/PlacesViewController.swift
+++ b/Campus Density/Controllers/PlacesViewController.swift
@@ -202,6 +202,7 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
                 if gotDensities {
                     API.status { gotStatus in
                         if gotStatus {
+                            sortPlaces() // Maybe fixes a bug related to opening the app after a long time and refreshed densities being out of order
                             self.filter(by: self.selectedFilter)
                             self.adapter.performUpdates(animated: false, completion: nil)
                         }
@@ -314,6 +315,7 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
                 self.filter(by: self.selectedFilter)
             }
             refreshControl.endRefreshing()
+            self.adapter.performUpdates(animated: false, completion: nil) // After refreshing, reload with sorted places - otherwise may just have same order with updated density card on cell dequeue and configure (passing the place by reference and updating the places) ?
         }
     }
 

--- a/Campus Density/DiningCells/FormLinkCell.swift
+++ b/Campus Density/DiningCells/FormLinkCell.swift
@@ -22,6 +22,7 @@ class FormLinkCell: UICollectionViewCell {
 
     // MARK: - View vars
     var linkButton: UIButton!
+    var lastUpdatedLabel: UILabel!
 
     // MARK: - Constants
     let linkButtonText = "Is this accurate?"
@@ -37,6 +38,12 @@ class FormLinkCell: UICollectionViewCell {
         linkButton.titleLabel?.textAlignment = .right
         addSubview(linkButton)
 
+        lastUpdatedLabel = UILabel()
+        lastUpdatedLabel.textColor = .densityDarkGray
+        lastUpdatedLabel.font = .fourteen
+        addSubview(lastUpdatedLabel)
+
+        setupConstraints()
     }
 
     func setupConstraints() {
@@ -44,11 +51,19 @@ class FormLinkCell: UICollectionViewCell {
             make.height.equalToSuperview()
             make.right.equalToSuperview().inset(Constants.smallPadding)
         }
+
+        lastUpdatedLabel.snp.makeConstraints { make in
+            make.height.equalToSuperview()
+            make.left.equalToSuperview().inset(Constants.smallPadding)
+        }
     }
 
-    func configure(delegate: FormLinkCellDelegate, link: String) {
+    func configure(delegate: FormLinkCellDelegate, link: String, lastUpdatedDate: Date) {
         self.delegate = delegate
         self.link = link
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        lastUpdatedLabel.text = "Last updated " + formatter.string(from: lastUpdatedDate)
         setupConstraints()
     }
 

--- a/Campus Density/DiningCells/LastUpdatedTextCell.swift
+++ b/Campus Density/DiningCells/LastUpdatedTextCell.swift
@@ -1,0 +1,48 @@
+//
+//  LastUpdatedTextCell.swift
+//  Campus Density
+//
+//  Created by Changyuan Lin on 7/2/20.
+//  Copyright © 2020 Cornell DTI. All rights reserved.
+//
+
+import UIKit
+
+class LastUpdatedTextCell: UICollectionViewCell {
+
+    // MARK: - View vars
+    var lastUpdatedLabel: UILabel!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        lastUpdatedLabel = UILabel()
+        lastUpdatedLabel.textColor = .densityDarkGray
+        lastUpdatedLabel.textAlignment = .center
+        lastUpdatedLabel.font = .sixteen
+        addSubview(lastUpdatedLabel)
+
+        setupConstraints()
+    }
+
+    func setupConstraints() {
+        lastUpdatedLabel.snp.makeConstraints { make in
+            make.width.equalToSuperview()
+            make.centerX.equalToSuperview()
+            make.height.equalToSuperview()
+        }
+    }
+
+    func configure(lastUpdatedDate: Date) {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        lastUpdatedLabel.text = "Last updated " + formatter.string(from: lastUpdatedDate)
+        setupConstraints()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/Campus Density/DiningCells/SpaceCell.swift
+++ b/Campus Density/DiningCells/SpaceCell.swift
@@ -17,7 +17,7 @@ class SpaceCell: UICollectionViewCell {
         super.init(frame: frame)
 
         space = UIView()
-        space.backgroundColor = .white
+        space.backgroundColor = .clear
         addSubview(space)
 
         space.snp.makeConstraints { make in

--- a/Campus Density/DiningModels/FormLinkModel.swift
+++ b/Campus Density/DiningModels/FormLinkModel.swift
@@ -12,10 +12,12 @@ import IGListKit
 class FormLinkModel {
 
     var feedbackForm: String
+    var lastUpdated: Date
     let identifier = UUID().uuidString
 
-    init(feedbackForm: String) {
+    init(feedbackForm: String, lastUpdated: Date) {
         self.feedbackForm = feedbackForm
+        self.lastUpdated = lastUpdated
     }
 
 }

--- a/Campus Density/DiningModels/LastUpdatedTextModel.swift
+++ b/Campus Density/DiningModels/LastUpdatedTextModel.swift
@@ -1,0 +1,30 @@
+//
+//  LastUpdatedTextModel.swift
+//  Campus Density
+//
+//  Created by Changyuan Lin on 6/27/20.
+//  Copyright © 2020 Cornell DTI. All rights reserved.
+//
+
+import Foundation
+import IGListKit
+
+class LastUpdatedTextModel {
+
+    let identifier = UUID().uuidString
+
+}
+
+extension LastUpdatedTextModel: ListDiffable {
+
+    func diffIdentifier() -> NSObjectProtocol {
+        return identifier as NSString
+    }
+
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
+        if self === object { return true }
+        guard let object = object as? LastUpdatedTextModel else { return false }
+        return object.identifier == identifier
+    }
+
+}

--- a/Campus Density/DiningModels/LastUpdatedTextModel.swift
+++ b/Campus Density/DiningModels/LastUpdatedTextModel.swift
@@ -11,7 +11,12 @@ import IGListKit
 
 class LastUpdatedTextModel {
 
+    var lastUpdated: Date
     let identifier = UUID().uuidString
+
+    init(lastUpdated: Date) {
+        self.lastUpdated = lastUpdated
+    }
 
 }
 

--- a/Campus Density/SectionControllers/FormLinkSectionController.swift
+++ b/Campus Density/SectionControllers/FormLinkSectionController.swift
@@ -36,7 +36,7 @@ class FormLinkSectionController: ListSectionController {
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: FormLinkCell.self, for: self, at: index) as! FormLinkCell
-        cell.configure(delegate: self, link: formLinkModel.feedbackForm)
+        cell.configure(delegate: self, link: formLinkModel.feedbackForm, lastUpdatedDate: formLinkModel.lastUpdated)
         return cell
     }
 

--- a/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
+++ b/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
@@ -14,20 +14,21 @@ class LastUpdatedTextSectionController: ListSectionController {
     // MARK: - 'Data' vars
     var lastUpdatedTextModel: LastUpdatedTextModel!
 
+    // MARK: - Constants
+    let cellHeight: CGFloat = 20
+
     init(lastUpdatedTextModel: LastUpdatedTextModel) {
         self.lastUpdatedTextModel = lastUpdatedTextModel
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
         guard let containerSize = collectionContext?.containerSize else { return .zero }
-//        let textHeight = headerText.height(withConstrainedWidth: containerSize.width - Constants.smallPadding * 2, font: .thirtyBold)
-        let textHeight = Constants.mediumPadding
-        return CGSize(width: containerSize.width, height: textHeight)
+        return CGSize(width: containerSize.width, height: cellHeight)
     }
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
-        let cell = collectionContext?.dequeueReusableCell(of: GraphHeaderCell.self, for: self, at: index) as! GraphHeaderCell
-        // cell configure
+        let cell = collectionContext?.dequeueReusableCell(of: LastUpdatedTextCell.self, for: self, at: index) as! LastUpdatedTextCell
+        cell.configure(lastUpdatedDate: lastUpdatedTextModel.lastUpdated)
         return cell
     }
 

--- a/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
+++ b/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
@@ -1,0 +1,38 @@
+//
+//  LastUpdatedTextSectionController.swift
+//  Campus Density
+//
+//  Created by Changyuan Lin on 6/27/20.
+//  Copyright © 2020 Cornell DTI. All rights reserved.
+//
+
+import Foundation
+import IGListKit
+
+class LastUpdatedTextSectionController: ListSectionController {
+
+    // MARK: - 'Data' vars
+    var lastUpdatedTextModel: LastUpdatedTextModel!
+
+    init(lastUpdatedTextModel: LastUpdatedTextModel) {
+        self.lastUpdatedTextModel = lastUpdatedTextModel
+    }
+
+    override func sizeForItem(at index: Int) -> CGSize {
+        guard let containerSize = collectionContext?.containerSize else { return .zero }
+//        let textHeight = headerText.height(withConstrainedWidth: containerSize.width - Constants.smallPadding * 2, font: .thirtyBold)
+        let textHeight = Constants.mediumPadding
+        return CGSize(width: containerSize.width, height: textHeight)
+    }
+
+    override func cellForItem(at index: Int) -> UICollectionViewCell {
+        let cell = collectionContext?.dequeueReusableCell(of: GraphHeaderCell.self, for: self, at: index) as! GraphHeaderCell
+        // cell configure
+        return cell
+    }
+
+    override func didUpdate(to object: Any) {
+        lastUpdatedTextModel = object as? LastUpdatedTextModel
+    }
+
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds the "last updated at" text to both the bottom of the places list and on the left side of the "is this accurate" cell of the detail view. Currently, it keeps track of when the API call for getting densities last succeeded and rounds that down to the most recent 5 minutes. This pull request also contains small code changes for making the space cells clear instead of white and removes some unnecessary comparison code. Possibly also fixes two refresh-related bugs.

- [x] added tracking of last updated density time in API
- [x] implemented standalone last updated text for places view
- [x] implemented last updated text as part of form link cell in detail view
- [x] fixed space cell background color and possibly some refresh bugs

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
![Screen Shot 2020-07-10 at 22 54 15](https://user-images.githubusercontent.com/22627336/87217050-7cd66e00-c302-11ea-9cb0-84e6e2545951.png)
![Screen Shot 2020-07-10 at 22 54 27](https://user-images.githubusercontent.com/22627336/87217049-7a741400-c302-11ea-8537-32b6e0e400b7.png)

Here we see the unavailable hours are also greyed out on the graph. Thanks @benjamin-shen (#29)

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

Initially, the last updated text relied on getting the current time and rounding it down whenever the objects were made for the list adapter. However, this had the side effect of making it appear that the data refreshed whenever the view refreshed, i.e. just pressing the button to change the filter on the places view or changing the selected date in the detail view would sometimes make it look like the data also refreshed. This was fixed (and logically improved) by remembering when the last API call succeeded and rounding it down as needed.