### PR TITLE
Some docs for PlaceDetail, Places, and feedback questions

### DIFF
--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -165,25 +165,39 @@ struct HistoricalData: Codable {
 
 }
 
+/// Group of individual menu items under one category such as "Grill Station"
 struct MenuItem: Codable {
+    /// List of individual food items
     var items: [String]
+    /// The "station" that these food items are available at, e.g. "Salad Bar Station", "Cereal/Bagel Bar"
     var category: String
 }
 
+/// The menu for one meal at a particular dining hall on a particular day.
 struct MenuData: Codable {
+    /// List of menu items, grouped by category (see `MenuItem`)
     var menu: [MenuItem]
+    /// The meal description, e.g. "Lunch"
     var description: String
+    /// The absolute start time of this meal, in Unix time
     var startTime: Int
+    /// The absolute end time of this meal, in Unix time
     var endTime: Int
 }
 
+/// All menu data for a dining hall on a particular day.
 struct DayMenus: Codable {
+    /// The list of meal menus, ordered in breakfast, lunch, dinner (could be brunch)
     var menus: [MenuData]
+    /// The date that these menus belong to, e.g. "2020-12-17"
     var date: String
 }
 
+/// A week's worth of menus for a particular dining hall.
 struct WeekMenus: Codable {
+    /// The list of menus for each day, in chronological order
     var weeksMenus: [DayMenus]
+    /// Eatery id, e.g. "becker"
     var id: String
 }
 

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import IGListKit
 import Firebase
 
+/// The meal (breakfast, brunch, lunch, dinner) to view the menus of.
 enum Meal: String, CaseIterable {
     case none = "No"
     case breakfast = "Breakfast"
@@ -18,6 +19,8 @@ enum Meal: String, CaseIterable {
     case dinner = "Dinner"
 }
 
+/// The view controller that handles detailed display of one `Place`.
+/// This view controller is at the heart of the app, as it hosts the open hours, day chips, and menus.
 class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Data vars
@@ -26,7 +29,8 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
     var selectedHour: Int = 0
     var mealList = [Meal]()
     var selectedMeal: Meal = .none
-    var weekdays = [(Int, Int)]() // (weekday, dayNum) as in (0, 5) for Sunday the 5th
+    /// The next days, indexed at the current day and storing (weekday, dayNum) as (0, 5) for Sunday the 5th
+    var weekdays = [(Int, Int)]()
     var densityMap = [Int: Double]()
     var adapter: ListAdapter!
     var loadingHours: Bool = true
@@ -167,6 +171,7 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
 
+    /// Display an alert that eatery data failed to load.
     func alertError(completion: @escaping () -> Void) {
         let alertController = UIAlertController(title: "Error", message: "Failed to load data. Check your network connection.", preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "Try Again", style: .default, handler: { _ in
@@ -184,6 +189,8 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
         setupViews()
     }
 
+    /// Set the upcoming days of the week.
+    /// Used to show day chips in the right order, including day of week and day of month.
     func setWeekdays() {
         let today = Date()
         weekdays = []
@@ -195,6 +202,7 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
 
+    /// The current hour of the day in the dining hall's local time
     func getCurrentHour() -> Int {
         let today = Date()
         return ithacaCalendar.component(.hour, from: today)
@@ -295,18 +303,24 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
         }
     }
 
+    /// The current numerical day of week in the dining hall's timezone.
+    /// - Returns: A number representing the day of week. See `Calendar` for more information.
     func getCurrentWeekday() -> Int {
         let today = Date()
         return ithacaCalendar.component(.weekday, from: today) - 1
     }
 
+    /// The current localized string representation of day of week in the dining hall's timezone.
+    /// - Returns: A string representing day of week, e.g. "Sunday"
     func selectedWeekdayText() -> String {
         return ithacaCalendar.weekdaySymbols[selectedWeekday]
     }
 
+    /// A  user-facing string representation of the date. Includes the time zone if the user's local time zone is not equal to Eastern Time.
+    /// - Returns: A string in the form "MMMM dd EDT", with the time zone being optional.
     func selectedDateText() -> String {
         let today = Date()
-        guard let weekdayIndex = weekdays.firstIndex(where: {$0.0 == selectedWeekday}) else { return "" }
+        guard let weekdayIndex = weekdays.firstIndex(where: { $0.0 == selectedWeekday }) else { return "" }
         guard let selectedDate = ithacaCalendar.date(byAdding: Calendar.Component.day, value: weekdayIndex, to: today) else { return "" }
         let formatter = DateFormatter()
         formatter.timeZone = ithacaTime

--- a/Campus Density/Controllers/PlacesViewController.swift
+++ b/Campus Density/Controllers/PlacesViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  PlacesViewController.swift
 //  Campus Density
 //
 //  Created by Matthew Coufal on 10/14/18.
@@ -10,6 +10,7 @@ import SnapKit
 import Firebase
 import IGListKit
 
+/// Region to filter eatery locations by
 enum Filter: String {
     case all = "All"
     case north = "North"
@@ -17,6 +18,7 @@ enum Filter: String {
     case central = "Central"
 }
 
+/// The main-screen view controller of the app. It contains the scrollable list of eateries that lead to detail views.
 class PlacesViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Data vars
@@ -90,6 +92,7 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
         setupGestureRecognizers()
     }
 
+    /// Attempt to sign in and update the eatery data
     func signIn() {
         if let user = Auth.auth().currentUser {
             if System.token != nil {
@@ -141,6 +144,7 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
         }
     }
 
+    /// Display an alert that eatery data failed to load.
     func alertError() {
         let alertController = UIAlertController(title: "Error", message: "Failed to load data. Check your network connection.", preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: "Try Again", style: .default, handler: { _ in
@@ -219,7 +223,6 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
 
     override func viewDidAppear(_ animated: Bool) {
         navigationController?.navigationBar.prefersLargeTitles = true
-
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -227,24 +230,16 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
         updatePlaces()
     }
 
-    func filterLabel(filter: Filter) -> String {
-        switch filter {
-        case .all:
-            return "All"
-        case .central:
-            return "Central"
-        case .north:
-            return "North"
-        case .west:
-            return "West"
-        }
-    }
-
     /// Update `filteredPlaces` by filtering through current location filter and then search filter
     func updateFilteredPlaces() {
         filteredPlaces = filter(places: filter(places: System.places, by: self.selectedFilter), by: self.searchText)
     }
 
+    /// Filter a list of eateries by region.
+    /// - Parameters:
+    ///   - places: List of eateries
+    ///   - selectedFilter: Region to filter by, may be `.all`
+    /// - Returns: A new list only containing places whose region satisfies the filter
     func filter(places: [Place], by selectedFilter: Filter) -> [Place] {
         var filteredPlaces: [Place] = []
         print("Filtering by \(selectedFilter)")
@@ -268,6 +263,11 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
         return filteredPlaces
     }
 
+    /// Filter a list of eateries to those whose names contain a substring.
+    /// - Parameters:
+    ///   - places: List of eateries
+    ///   - text: String to filter display name by
+    /// - Returns: A new list containing places whose display name contains `text`
     func filter(places: [Place], by text: String) -> [Place] {
         var filteredPlaces: [Place] = []
         print("Filtering by \(text)")
@@ -282,6 +282,7 @@ class PlacesViewController: UIViewController, UIScrollViewDelegate {
         return filteredPlaces
     }
 
+    /// Set up pull-to-refesh functionality at top of page
     func setupRefreshControl() {
         if refreshBarsView != nil {
             refreshBarsView.removeFromSuperview()

--- a/Campus Density/FeedbackQuestions/AccuracyQuestion.swift
+++ b/Campus Density/FeedbackQuestions/AccuracyQuestion.swift
@@ -12,6 +12,7 @@ protocol AccuracyQuestionDelegate: class {
     func accuracyWasChanged(isAccurate: Bool)
 }
 
+/// Feedback question asking if Flux information is accurate. Radio buttons yes/no.
 class AccuracyQuestion: FeedbackQuestion {
     weak var delegate: AccuracyQuestionDelegate?
     let yesLabel = UILabel()
@@ -53,12 +54,14 @@ class AccuracyQuestion: FeedbackQuestion {
         }
     }
 
+    /// Update the radio buttons to reflect that the information is accurate. Also notifies its delegate.
     func yesButtonPressed() {
         yesButton.backgroundColor = .black
         noButton.backgroundColor = .clear
         delegate?.accuracyWasChanged(isAccurate: true)
     }
 
+    /// Update the radio buttons to reflect that the information is not accurate. Also notifies its delegate.
     func noButtonPressed() {
         yesButton.backgroundColor = .clear
         noButton.backgroundColor = .black

--- a/Campus Density/FeedbackQuestions/FeedbackQuestion.swift
+++ b/Campus Density/FeedbackQuestions/FeedbackQuestion.swift
@@ -8,10 +8,15 @@
 
 import UIKit
 
+/// A blank feedback question
 class FeedbackQuestion: UIView {
     var title = UILabel()
     var subtitle = UILabel()
 
+    /// Initialize a blank feedback question, optionally with custom title/subtitle
+    /// - Parameters:
+    ///   - title: Question title, default "Accuracy Feedback"
+    ///   - subtitle: Question subtitle, default empty
     init(title: String = "Accuracy Feedback", subtitle: String = "") {
         super.init(frame: .zero)
         self.title.text = title

--- a/Campus Density/FeedbackQuestions/ObservedDensityQuestion.swift
+++ b/Campus Density/FeedbackQuestions/ObservedDensityQuestion.swift
@@ -12,6 +12,7 @@ protocol ObservedDensityQuestionDelegate: class {
     func observedDensityWasChanged(observed: Int)
 }
 
+/// Feedback question with Flux pills to ask for observed density/crowdedness
 class ObservedDensityQuestion: FeedbackQuestion {
     weak var delegate: ObservedDensityQuestionDelegate?
     let colors: [UIColor] = [.lightTeal, .wheat, .peach, .orangeyRed] // From CurrentDensityCell
@@ -78,6 +79,8 @@ class ObservedDensityQuestion: FeedbackQuestion {
         }
     }
 
+    /// Update color pills and radio buttons to reflect a new selected density. Also notifies its delegate of the change.
+    /// - Parameter density: A number 0-3, with 0 being "not busy" and 3 being "very busy"
     func changeObservedDensity(density: Int) {
         let densityColor = colors[density]
         for i in 0...3 {

--- a/Campus Density/FeedbackQuestions/ThanksQuestion.swift
+++ b/Campus Density/FeedbackQuestions/ThanksQuestion.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+/// Non-interactive display of Thank You question
 class ThanksQuestion: FeedbackQuestion {
     let thanksImageView = UIImageView(image: UIImage(named: "thanks"))
     let thanksLabel = UILabel()

--- a/Campus Density/FeedbackQuestions/WaitTimeQuestion.swift
+++ b/Campus Density/FeedbackQuestions/WaitTimeQuestion.swift
@@ -12,6 +12,7 @@ protocol WaitTimeQuestionDelegate: class {
     func waitTimeWasChanged(waitTime: Int)
 }
 
+/// Feedback question asking for observed wait time using a `PickerView`
 class WaitTimeQuestion: FeedbackQuestion, UIPickerViewDataSource, UIPickerViewDelegate {
     weak var delegate: WaitTimeQuestionDelegate?
     let options = ["0-2", "2-4", "4-6", "6-8", "8-10", "10-12", "12-14", "14-16", "16-18", "18-20", "20+"]


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

Added some documentation, written in markdown so it shows up in quick help (option + click). Flux iOS severely lacks important documentation in some areas so this is the first step towards remedying the hard to understand structure of the application.

I explored Swift documentation generators such as [Jazzy](https://github.com/realm/jazzy), but ran into installation issues related to Xcode versions and macOS. After working through those by substituting in Xcode 11 as I didn't want to risk updating my operating system at the moment, there were still issues running the docs generator. I believe that this is related to the workaround that we had to incorporate for Xcode 12, where we had to prevent the computer from trying to build or run arm64 during development. This issue is worth looking into a bit further if we want HTML pages to browse Flux documentation, but if we are fine with in-IDE documentation only then it might not be necessary. For now though, I have added some documentation for `PlaceDetailViewController`, `PlacesViewController`, the two main parts of the app, and the feedback questions in my last PR.

- [x] added some docs
- [ ] solved world hunger
