### PR TITLE
Cleaner place hours

### DIFF
--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -141,9 +141,16 @@ class Token: Codable {
     }
 }
 
+struct DailyHours: Codable {
+
+    var startTimestamp: Double
+    var endTimestamp: Double
+
+}
+
 struct DailyInfo: Codable {
 
-    var dailyHours: [String: Double]
+    var dailyHours: DailyHours
     var date: String
     var dayOfWeek: Int
     var status: String

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -49,11 +49,11 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             }
         }
         return [
-            DetailControllerHeaderModel(place: place),
+            DetailControllerHeaderModel(displayName: place.displayName, hours: place.hours),
             SpaceModel(space: Constants.smallPadding),
             AvailabilityHeaderModel(),
             SpaceModel(space: Constants.smallPadding),
-            AvailabilityInfoModel(place: place),
+            AvailabilityInfoModel(place: place), // TODO: look into only passing what's necessary
             SpaceModel(space: linkTopOffset),
             FormLinkModel(lastUpdated: lastUpdatedTime),
             SpaceModel(space: Constants.mediumPadding),

--- a/Campus Density/DiningCells/DetailControllerHeaderCell.swift
+++ b/Campus Density/DiningCells/DetailControllerHeaderCell.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class DetailControllerHeaderCell: UICollectionViewCell {
 
-    var place: Place!
     var displayLabel: UILabel!
     var timeString: NSMutableAttributedString!
     var timeLabel: UILabel!
@@ -64,23 +63,15 @@ class DetailControllerHeaderCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(with place: Place) {
-        self.place = place
-        displayLabel.text = place.displayName
-        if place.displayName.count >= 23 {
+    func configure(displayName: String, hours: [DailyInfo]) {
+        displayLabel.text = displayName
+        if displayName.count >= 23 {
             displayLabel.font = .twentyEightBold
         }
 
-        if place.isClosed {
-            timeString = NSMutableAttributedString(string: "Closed")
-            timeString.addAttribute(.foregroundColor, value: UIColor.orangeyRed, range: NSRange(location: 0, length: timeString.mutableString.length))
-        } else {
-            let closingString = getNextClosingText()
-            timeString = NSMutableAttributedString(string: "Open until \(closingString)")
-            timeString.addAttribute(.foregroundColor, value: UIColor.lightTeal, range: NSRange(location: 0, length: timeString.mutableString.length))
-        }
-
-        timeLabel.attributedText = timeString
+        let timeText = getNextClosingText()
+        let attributes = [NSAttributedString.Key.foregroundColor: (timeText == "Closed" ? UIColor.orangeyRed : UIColor.lightTeal)]
+        timeLabel.attributedText = NSMutableAttributedString(string: timeText, attributes: attributes)
     }
 
     /**

--- a/Campus Density/DiningCells/DetailControllerHeaderCell.swift
+++ b/Campus Density/DiningCells/DetailControllerHeaderCell.swift
@@ -75,7 +75,7 @@ class DetailControllerHeaderCell: UICollectionViewCell {
     }
 
     /**
-     Returns a user-facing string representing the next closing time for this place.
+     Returns a user-facing string representing the next closing time for this place, e.g. "Open until 8:30 PM" or "Closed"
     */
     func getNextClosingText(hours: [DailyInfo]) -> String {
 

--- a/Campus Density/DiningModels/DetailControllerHeaderModel.swift
+++ b/Campus Density/DiningModels/DetailControllerHeaderModel.swift
@@ -11,11 +11,13 @@ import IGListKit
 
 class DetailControllerHeaderModel {
 
-    var place: Place!
+    var displayName: String
+    var hours: [DailyInfo]
     var identifier = UUID().uuidString
 
-    init(place: Place) {
-        self.place = place
+    init(displayName: String, hours: [DailyInfo]) {
+        self.displayName = displayName
+        self.hours = hours
     }
 }
 

--- a/Campus Density/SectionControllers/DetailControllerHeaderSectionController.swift
+++ b/Campus Density/SectionControllers/DetailControllerHeaderSectionController.swift
@@ -25,7 +25,7 @@ class DetailControllerHeaderSectionController: ListSectionController {
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: DetailControllerHeaderCell.self, for: self, at: index) as! DetailControllerHeaderCell
-        cell.configure(with: headerModel.place)
+        cell.configure(displayName: headerModel.displayName, hours: headerModel.hours)
         return cell
     }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request cleans up the path that hours data takes through the iOS app. Previously, the received hours data was processed immediately into user-facing strings containing newlines and dashes. It was originally used (a long time ago) for the hours label on the places detail view, but that has since been replaced with hours labels attached to the menu for each meal, which are handled differently. However, the stringy hours were still used in #31 for the "Open until..." and "Closed" text on the places detail view header.

In this pull request, the "data -> string -> re-parse obsolete string format -> label text" has been fixed by changing `Place.hours` to be `[DailyInfo]` and reworking the related code. Unnecessary passing of `Place` objects directly to data models and cells has also been reduced to only passing relevant information such as display name and hours.

- [x] big cleanup of how place hours work

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

Checked it visually looks the same, both on open and closed dining locations

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->
- hours are handled differently internally but nothing else was depending on them at the moment
