### PR TITLE
Wait times

### DIFF
--- a/Campus Density.xcodeproj/xcshareddata/xcschemes/Campus Density Dev.xcscheme
+++ b/Campus Density.xcodeproj/xcshareddata/xcschemes/Campus Density Dev.xcscheme
@@ -27,8 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <Testables>
-      </Testables>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -38,8 +36,8 @@
             ReferencedContainer = "container:Campus Density.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
+      <Testables>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -61,8 +59,6 @@
             ReferencedContainer = "container:Campus Density.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -90,7 +90,7 @@ class Place: ListDiffable {
     var displayName: String
     var id: String
     var density: Density
-    var waitTime: Int?
+    var waitTime: Double?
     var isClosed: Bool
     var hours: [DailyInfo]
     var history: [String: [String: Double]]
@@ -108,7 +108,7 @@ class Place: ListDiffable {
     ///   - history: TODO
     ///   - region: A `Region` instance specifying where this object is located on campus
     ///   - menus: A `WeekMenus` instance representing all the menus for this eatery for the entire week, starting from today.
-    init(displayName: String, id: String, density: Density, waitTime: Int?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, menus: WeekMenus) {
+    init(displayName: String, id: String, density: Density, waitTime: Double?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, menus: WeekMenus) {
         self.displayName = displayName
         self.id = id
         self.density = density
@@ -259,7 +259,7 @@ class API {
         AF.request("\(url)/waitTime", headers: headers)
             .responseData { response in
                 let decoder = JSONDecoder()
-                let result: AFResult<[String: Int]> = decoder.decodeResponse(from: response)
+                let result: AFResult<[String: Double]> = decoder.decodeResponse(from: response)
                 switch result {
                 case .success(let data):
                     data.forEach { id, waitTime in

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -90,7 +90,7 @@ class Place: ListDiffable {
     var displayName: String
     var id: String
     var density: Density
-    var waitTime: Int
+    var waitTime: Int?
     var isClosed: Bool
     var hours: [DailyInfo]
     var history: [String: [String: Double]]
@@ -108,7 +108,7 @@ class Place: ListDiffable {
     ///   - history: TODO
     ///   - region: A `Region` instance specifying where this object is located on campus
     ///   - menus: A `WeekMenus` instance representing all the menus for this eatery for the entire week, starting from today.
-    init(displayName: String, id: String, density: Density, waitTime: Int, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, menus: WeekMenus) {
+    init(displayName: String, id: String, density: Density, waitTime: Int?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, menus: WeekMenus) {
         self.displayName = displayName
         self.id = id
         self.density = density
@@ -318,7 +318,7 @@ class API {
                 switch result {
                 case .success(let placeNames):
                     System.places = placeNames.map { placeName in
-                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: -1, isClosed: false, hours: [], history: [:], region: .north, menus: WeekMenus(weeksMenus: [], id: placeName.id))
+                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: nil, isClosed: false, hours: [], history: [:], region: .north, menus: WeekMenus(weeksMenus: [], id: placeName.id))
                     }
                     completion(true)
                 case .failure(let error):

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -57,7 +57,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             SpaceModel(space: linkTopOffset),
             AvailabilityInfoModel(place: place), // TODO: look into only passing what's necessary
             SpaceModel(space: linkTopOffset),
-            FormLinkModel(lastUpdated: lastUpdatedTime),
+            FormLinkModel(isClosed: place.isClosed, waitTime: place.waitTime),
             SpaceModel(space: Constants.mediumPadding),
             DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays),
             SpaceModel(space: Constants.smallPadding),

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -53,6 +53,8 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             SpaceModel(space: Constants.smallPadding),
             AvailabilityHeaderModel(),
             SpaceModel(space: Constants.smallPadding),
+            LastUpdatedTextModel(lastUpdated: lastUpdatedTime),
+            SpaceModel(space: linkTopOffset),
             AvailabilityInfoModel(place: place), // TODO: look into only passing what's necessary
             SpaceModel(space: linkTopOffset),
             FormLinkModel(lastUpdated: lastUpdatedTime),
@@ -102,6 +104,9 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         } else if object is AvailabilityHeaderModel {
             let availabilityHeaderModel = object as! AvailabilityHeaderModel
             return AvailabilityHeaderSectionController(headerModel: availabilityHeaderModel)
+        } else if object is LastUpdatedTextModel {
+            let lastUpdatedTextModel = object as! LastUpdatedTextModel
+            return LastUpdatedTextSectionController(lastUpdatedTextModel: lastUpdatedTextModel, style: .detail)
         } else {
             let menuHeaderModel = object as! MenuHeaderModel
             return MenuHeaderSectionController(menuHeaderModel: menuHeaderModel)

--- a/Campus Density/Controllers/PlacesViewController+Extension.swift
+++ b/Campus Density/Controllers/PlacesViewController+Extension.swift
@@ -43,7 +43,7 @@ extension PlacesViewController: ListAdapterDataSource {
             return FiltersSectionController(filtersModel: filtersModel, delegate: self)
         } else if object is LastUpdatedTextModel {
             let lastUpdatedTextModel = object as! LastUpdatedTextModel
-            return LastUpdatedTextSectionController(lastUpdatedTextModel: lastUpdatedTextModel)
+            return LastUpdatedTextSectionController(lastUpdatedTextModel: lastUpdatedTextModel, style: .main)
         } else if object is LogoModel {
             let logoModel = object as! LogoModel
             return LogoSectionController(logoModel: logoModel, delegate: self)

--- a/Campus Density/DiningCells/FormLinkCell.swift
+++ b/Campus Density/DiningCells/FormLinkCell.swift
@@ -38,7 +38,7 @@ class FormLinkCell: UICollectionViewCell {
         addSubview(linkButton)
 
         waitTimeLabel = UILabel()
-        waitTimeLabel.textColor = .grayishBrown
+        waitTimeLabel.textColor = .densityDarkGray
         waitTimeLabel.font = .fourteen
         addSubview(waitTimeLabel)
 

--- a/Campus Density/DiningCells/FormLinkCell.swift
+++ b/Campus Density/DiningCells/FormLinkCell.swift
@@ -21,7 +21,7 @@ class FormLinkCell: UICollectionViewCell {
 
     // MARK: - View vars
     var linkButton: UIButton!
-    var lastUpdatedLabel: UILabel!
+    var waitTimeLabel: UILabel!
 
     // MARK: - Constants
     let linkButtonText = "Is this accurate?"
@@ -37,10 +37,10 @@ class FormLinkCell: UICollectionViewCell {
         linkButton.titleLabel?.textAlignment = .right
         addSubview(linkButton)
 
-        lastUpdatedLabel = UILabel()
-        lastUpdatedLabel.textColor = .densityDarkGray
-        lastUpdatedLabel.font = .fourteen
-        addSubview(lastUpdatedLabel)
+        waitTimeLabel = UILabel()
+        waitTimeLabel.textColor = .grayishBrown
+        waitTimeLabel.font = .fourteen
+        addSubview(waitTimeLabel)
 
         setupConstraints()
     }
@@ -51,17 +51,15 @@ class FormLinkCell: UICollectionViewCell {
             make.right.equalToSuperview().inset(Constants.smallPadding)
         }
 
-        lastUpdatedLabel.snp.makeConstraints { make in
+        waitTimeLabel.snp.makeConstraints { make in
             make.height.equalToSuperview()
             make.left.equalToSuperview().inset(Constants.smallPadding)
         }
     }
 
-    func configure(delegate: FormLinkCellDelegate, lastUpdatedDate: Date) {
+    func configure(delegate: FormLinkCellDelegate, isClosed: Bool, waitTime: Int?) {
         self.delegate = delegate
-        let formatter = DateFormatter()
-        formatter.timeStyle = .short
-        lastUpdatedLabel.text = "Last updated " + formatter.string(from: lastUpdatedDate)
+        waitTimeLabel.text = isClosed ? "Closed" : waitTimeText(waitTime: waitTime)
         setupConstraints()
     }
 

--- a/Campus Density/DiningCells/FormLinkCell.swift
+++ b/Campus Density/DiningCells/FormLinkCell.swift
@@ -57,7 +57,7 @@ class FormLinkCell: UICollectionViewCell {
         }
     }
 
-    func configure(delegate: FormLinkCellDelegate, isClosed: Bool, waitTime: Int?) {
+    func configure(delegate: FormLinkCellDelegate, isClosed: Bool, waitTime: Double?) {
         self.delegate = delegate
         waitTimeLabel.text = isClosed ? "Closed" : waitTimeText(waitTime: waitTime)
         setupConstraints()

--- a/Campus Density/DiningCells/LastUpdatedTextCell.swift
+++ b/Campus Density/DiningCells/LastUpdatedTextCell.swift
@@ -18,24 +18,32 @@ class LastUpdatedTextCell: UICollectionViewCell {
 
         lastUpdatedLabel = UILabel()
         lastUpdatedLabel.textColor = .densityDarkGray
-        lastUpdatedLabel.textAlignment = .center
-        lastUpdatedLabel.font = .sixteen
-        addSubview(lastUpdatedLabel)
+        contentView.addSubview(lastUpdatedLabel)
 
         setupConstraints()
     }
 
     func setupConstraints() {
         lastUpdatedLabel.snp.makeConstraints { make in
-            make.width.equalToSuperview()
-            make.centerX.equalToSuperview()
+            make.left.right.equalToSuperview().inset(Constants.smallPadding)
             make.height.equalToSuperview()
         }
     }
 
-    func configure(lastUpdatedDate: Date) {
+    func configure(lastUpdatedDate: Date, style: LastUpdatedTextSectionController.Style) {
         let formatter = DateFormatter()
-        formatter.dateStyle = .medium
+
+        switch style {
+        case .main:
+            formatter.dateStyle = .medium
+            lastUpdatedLabel.textAlignment = .center
+            lastUpdatedLabel.font = .sixteen
+        case .detail:
+            formatter.dateStyle = .none
+            lastUpdatedLabel.textAlignment = .left
+            lastUpdatedLabel.font = .fourteen
+        }
+
         formatter.timeStyle = .short
         lastUpdatedLabel.text = "Last updated " + formatter.string(from: lastUpdatedDate)
         setupConstraints()

--- a/Campus Density/DiningCells/PlaceCell.swift
+++ b/Campus Density/DiningCells/PlaceCell.swift
@@ -24,8 +24,7 @@ class PlaceCell: UICollectionViewCell {
     // MARK: - View vars
     var background: UIView!
     var nameLabel: UILabel!
-    var densityLabel: UILabel!
-    var capacityLabel: UILabel!
+    var waitTimeLabel: UILabel!
     var barOne: UIView!
     var barTwo: UIView!
     var barThree: UIView!
@@ -71,11 +70,11 @@ class PlaceCell: UICollectionViewCell {
         nameLabel.font = .sixteenBold
         contentView.addSubview(nameLabel)
 
-        densityLabel = UILabel()
-        densityLabel.adjustsFontSizeToFitWidth = true
-        densityLabel.textAlignment = .right
-        densityLabel.font = .fourteen
-        contentView.addSubview(densityLabel)
+        waitTimeLabel = UILabel()
+        waitTimeLabel.adjustsFontSizeToFitWidth = true
+        waitTimeLabel.textAlignment = .right
+        waitTimeLabel.font = .fourteen
+        contentView.addSubview(waitTimeLabel)
 
         barOne = setupBar()
         contentView.addSubview(barOne)
@@ -110,8 +109,8 @@ class PlaceCell: UICollectionViewCell {
 
         let barWidth: CGFloat = totalBarWidth / 4.0
 
-        guard let densityLabelText = densityLabel.text else { return }
-        let densityLabelWidth = densityLabelText.widthWithConstrainedHeight(labelHeight, font: densityLabel.font)
+        guard let waitTimeLabelText = waitTimeLabel.text else { return }
+        let waitTimeLabelWidth = waitTimeLabelText.widthWithConstrainedHeight(labelHeight, font: waitTimeLabel.font)
 
         background.snp.makeConstraints { make in
             make.top.equalToSuperview().offset(padding)
@@ -148,8 +147,8 @@ class PlaceCell: UICollectionViewCell {
             make.height.equalTo(barOne)
         }
 
-        densityLabel.snp.makeConstraints { make in
-            make.width.equalTo(densityLabelWidth)
+        waitTimeLabel.snp.makeConstraints { make in
+            make.width.equalTo(waitTimeLabelWidth)
             make.right.equalTo(background).inset(padding)
             make.top.equalTo(background)
             make.bottom.equalTo(barOne.snp.top)
@@ -158,21 +157,16 @@ class PlaceCell: UICollectionViewCell {
         nameLabel.snp.makeConstraints { make in
             make.left.equalTo(barOne)
             make.bottom.equalTo(barOne.snp.top)
-            make.right.equalTo(densityLabel.snp.left).offset(-5)
+            make.right.equalTo(waitTimeLabel.snp.left).offset(-5)
             make.top.equalTo(background)
         }
     }
 
-    func interpretDensity() -> String {
-        switch place.density {
-            case .veryBusy:
-                return "Very busy"
-            case .prettyBusy:
-                return "Pretty busy"
-            case .notBusy:
-                return "Not busy"
-            case .somewhatBusy:
-                return "Somewhat busy"
+    func waitTimeText() -> String {
+        if let waitTime = place.waitTime {
+            return "\(waitTime) min. Wait time"
+        } else {
+            return "? min. Wait time"
         }
     }
 
@@ -215,8 +209,8 @@ class PlaceCell: UICollectionViewCell {
     func configure(with place: Place) {
         self.place = place
         nameLabel.text = place.displayName
-        densityLabel.text = place.isClosed ? "Closed" : interpretDensity()
-        densityLabel.textColor = place.isClosed ? .orangeyRed : .densityDarkGray
+        waitTimeLabel.text = place.isClosed ? "Closed" : waitTimeText()
+        waitTimeLabel.textColor = place.isClosed ? .orangeyRed : .densityDarkGray
         colorBars()
         setupConstraints()
     }

--- a/Campus Density/DiningCells/PlaceCell.swift
+++ b/Campus Density/DiningCells/PlaceCell.swift
@@ -162,14 +162,6 @@ class PlaceCell: UICollectionViewCell {
         }
     }
 
-    func waitTimeText() -> String {
-        if let waitTime = place.waitTime {
-            return "\(waitTime) min. Wait time"
-        } else {
-            return "? min. Wait time"
-        }
-    }
-
     func colorBars() {
         if place.isClosed {
             barOne.backgroundColor = .whiteTwo
@@ -209,7 +201,7 @@ class PlaceCell: UICollectionViewCell {
     func configure(with place: Place) {
         self.place = place
         nameLabel.text = place.displayName
-        waitTimeLabel.text = place.isClosed ? "Closed" : waitTimeText()
+        waitTimeLabel.text = place.isClosed ? "Closed" : waitTimeText(waitTime: place.waitTime)
         waitTimeLabel.textColor = place.isClosed ? .orangeyRed : .densityDarkGray
         colorBars()
         setupConstraints()

--- a/Campus Density/DiningModels/FormLinkModel.swift
+++ b/Campus Density/DiningModels/FormLinkModel.swift
@@ -12,10 +12,10 @@ import IGListKit
 class FormLinkModel {
 
     var isClosed: Bool
-    var waitTime: Int?
+    var waitTime: Double?
     let identifier = UUID().uuidString
 
-    init(isClosed: Bool, waitTime: Int?) {
+    init(isClosed: Bool, waitTime: Double?) {
         self.isClosed = isClosed
         self.waitTime = waitTime
     }

--- a/Campus Density/DiningModels/FormLinkModel.swift
+++ b/Campus Density/DiningModels/FormLinkModel.swift
@@ -11,11 +11,13 @@ import IGListKit
 
 class FormLinkModel {
 
-    var lastUpdated: Date
+    var isClosed: Bool
+    var waitTime: Int?
     let identifier = UUID().uuidString
 
-    init(lastUpdated: Date) {
-        self.lastUpdated = lastUpdated
+    init(isClosed: Bool, waitTime: Int?) {
+        self.isClosed = isClosed
+        self.waitTime = waitTime
     }
 
 }

--- a/Campus Density/SectionControllers/FormLinkSectionController.swift
+++ b/Campus Density/SectionControllers/FormLinkSectionController.swift
@@ -36,7 +36,7 @@ class FormLinkSectionController: ListSectionController {
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: FormLinkCell.self, for: self, at: index) as! FormLinkCell
-        cell.configure(delegate: self, lastUpdatedDate: formLinkModel.lastUpdated)
+        cell.configure(delegate: self, isClosed: formLinkModel.isClosed, waitTime: formLinkModel.waitTime)
         return cell
     }
 

--- a/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
+++ b/Campus Density/SectionControllers/LastUpdatedTextSectionController.swift
@@ -11,14 +11,21 @@ import IGListKit
 
 class LastUpdatedTextSectionController: ListSectionController {
 
+    enum Style {
+        case main
+        case detail
+    }
+
     // MARK: - 'Data' vars
     var lastUpdatedTextModel: LastUpdatedTextModel!
+    var style: Style
 
     // MARK: - Constants
     let cellHeight: CGFloat = 20
 
-    init(lastUpdatedTextModel: LastUpdatedTextModel) {
+    init(lastUpdatedTextModel: LastUpdatedTextModel, style: Style) {
         self.lastUpdatedTextModel = lastUpdatedTextModel
+        self.style = style
     }
 
     override func sizeForItem(at index: Int) -> CGSize {
@@ -28,7 +35,7 @@ class LastUpdatedTextSectionController: ListSectionController {
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: LastUpdatedTextCell.self, for: self, at: index) as! LastUpdatedTextCell
-        cell.configure(lastUpdatedDate: lastUpdatedTextModel.lastUpdated)
+        cell.configure(lastUpdatedDate: lastUpdatedTextModel.lastUpdated, style: style)
         return cell
     }
 

--- a/Campus Density/Utils.swift
+++ b/Campus Density/Utils.swift
@@ -57,7 +57,7 @@ func waitTimeText(waitTime: Int?) -> String {
     if let time = waitTime {
         return "\(time) min. wait"
     } else {
-        return "? min. wait"
+        return "Unknown wait"
     }
 }
 

--- a/Campus Density/Utils.swift
+++ b/Campus Density/Utils.swift
@@ -53,6 +53,14 @@ func interpretDensity(place: Place) -> String {
     }
 }
 
+func waitTimeText(waitTime: Int?) -> String {
+    if let time = waitTime {
+        return "\(time) min. wait"
+    } else {
+        return "? min. wait"
+    }
+}
+
 func weekdayAbbreviation(weekday: Int) -> String {
     switch weekday {
         case 0:

--- a/Campus Density/Utils.swift
+++ b/Campus Density/Utils.swift
@@ -53,9 +53,9 @@ func interpretDensity(place: Place) -> String {
     }
 }
 
-func waitTimeText(waitTime: Int?) -> String {
+func waitTimeText(waitTime: Double?) -> String {
     if let time = waitTime {
-        return "\(time) min. wait"
+        return "\(Int(time)) min. wait"
     } else {
         return "Unknown wait"
     }


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request integrates the `/waitTime` endpoint in the app and uses it to display wait times on the main page and the detail page. The request is made once on the main page to get wait times for all locations. If a location is closed it displays "Closed" instead of "X min. wait" on both the main page and detail page. If the wait time is unavailable it displays "? min. wait". The last updated text in the FormLinkCell on the detail page was replaced by wait time text. The last updated text is now a variant of the LastUpdatedTextCell and is located above the availability card and below the availability header.

- [x] wait time endpoint integrate
- [x] wait time on main page
- [x] wait time on detail page

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

![Screen Shot 2021-02-28 at 15 47 12](https://user-images.githubusercontent.com/22627336/109433187-17440880-79dd-11eb-8396-9ee1c2507dd1.png)
![Screen Shot 2021-02-28 at 15 47 16](https://user-images.githubusercontent.com/22627336/109433188-190dcc00-79dd-11eb-9b7d-6a40001cdd19.png)
