### PR TITLE
Days filter modified

### DIFF
--- a/Campus Density.xcodeproj/project.pbxproj
+++ b/Campus Density.xcodeproj/project.pbxproj
@@ -48,6 +48,10 @@
 		0CC6B74621B0AF1400E7B359 /* System.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC6B74521B0AF1400E7B359 /* System.swift */; };
 		0CC6B74921B0D52B00E7B359 /* LoadingBarsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC6B74821B0D52B00E7B359 /* LoadingBarsView.swift */; };
 		3A140B08DF4E0819AFC1184A /* Pods_Campus_Density.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9430CFB8EC63D630A3283564 /* Pods_Campus_Density.framework */; };
+		3A4F39E826108C5500B03C59 /* ActivityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F39E726108C5500B03C59 /* ActivityView.swift */; };
+		3A4F39ED26108CAA00B03C59 /* SectionDividerSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F39EC26108CAA00B03C59 /* SectionDividerSectionController.swift */; };
+		3A4F39F226108CF000B03C59 /* SectionDividerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F39F126108CF000B03C59 /* SectionDividerModel.swift */; };
+		3A4F39F726108D3000B03C59 /* SectionDividerCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4F39F626108D3000B03C59 /* SectionDividerCell.swift */; };
 		3C29547D25856E6F00965D9A /* AccuracyQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29547C25856E6F00965D9A /* AccuracyQuestion.swift */; };
 		3C29548525856EDE00965D9A /* ObservedDensityQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29548425856EDE00965D9A /* ObservedDensityQuestion.swift */; };
 		3C29548A25858D0200965D9A /* WaitTimeQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29548925858D0200965D9A /* WaitTimeQuestion.swift */; };
@@ -162,6 +166,10 @@
 		0CC6B74821B0D52B00E7B359 /* LoadingBarsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingBarsView.swift; sourceTree = "<group>"; };
 		125DB691B65A1E80E57A3B58 /* Pods-Campus DensityTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Campus DensityTests.debug.xcconfig"; path = "Target Support Files/Pods-Campus DensityTests/Pods-Campus DensityTests.debug.xcconfig"; sourceTree = "<group>"; };
 		355A9D3241FBB93485463234 /* Pods-Campus Density.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Campus Density.debug.xcconfig"; path = "Target Support Files/Pods-Campus Density/Pods-Campus Density.debug.xcconfig"; sourceTree = "<group>"; };
+		3A4F39E726108C5500B03C59 /* ActivityView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityView.swift; sourceTree = "<group>"; };
+		3A4F39EC26108CAA00B03C59 /* SectionDividerSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionDividerSectionController.swift; sourceTree = "<group>"; };
+		3A4F39F126108CF000B03C59 /* SectionDividerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionDividerModel.swift; sourceTree = "<group>"; };
+		3A4F39F626108D3000B03C59 /* SectionDividerCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionDividerCell.swift; sourceTree = "<group>"; };
 		3C29547C25856E6F00965D9A /* AccuracyQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccuracyQuestion.swift; sourceTree = "<group>"; };
 		3C29548425856EDE00965D9A /* ObservedDensityQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedDensityQuestion.swift; sourceTree = "<group>"; };
 		3C29548925858D0200965D9A /* WaitTimeQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitTimeQuestion.swift; sourceTree = "<group>"; };
@@ -259,6 +267,7 @@
 			isa = PBXGroup;
 			children = (
 				0CC6B74121B0A43C00E7B359 /* LogoView.swift */,
+				3A4F39E726108C5500B03C59 /* ActivityView.swift */,
 				0CC6B74821B0D52B00E7B359 /* LoadingBarsView.swift */,
 			);
 			path = Views;
@@ -268,6 +277,7 @@
 			isa = PBXGroup;
 			children = (
 				0C8B6D5E2232436600058AE6 /* SpaceModel.swift */,
+				3A4F39F126108CF000B03C59 /* SectionDividerModel.swift */,
 				0C209B0E224823560007AFA9 /* LogoModel.swift */,
 				0C209B1822482D610007AFA9 /* FiltersModel.swift */,
 				0C8B6D602232441C00058AE6 /* CurrentDensityModel.swift */,
@@ -292,6 +302,7 @@
 			isa = PBXGroup;
 			children = (
 				0C8B6D6D22324C3400058AE6 /* SpaceSectionController.swift */,
+				3A4F39EC26108CAA00B03C59 /* SectionDividerSectionController.swift */,
 				0C8B6D7122324F1200058AE6 /* CurrentDensitySectionController.swift */,
 				0CB3BF732232BC4A00A5B371 /* FormLinkSectionController.swift */,
 				0CB3BF772232BF3200A5B371 /* DaySelectionSectionController.swift */,
@@ -382,6 +393,7 @@
 				0C8B6D7322324FFA00058AE6 /* CurrentDensityCell.swift */,
 				0CB3BF752232BCC400A5B371 /* FormLinkCell.swift */,
 				0CB3BF792232C0F700A5B371 /* DaySelectionCell.swift */,
+				3A4F39F626108D3000B03C59 /* SectionDividerCell.swift */,
 				0CB3BF7D2232C50D00A5B371 /* GraphCell.swift */,
 				0C209B12224825AF0007AFA9 /* PlaceCell.swift */,
 				0C209B16224829280007AFA9 /* LogoCell.swift */,
@@ -722,11 +734,14 @@
 				EE4C804324A751E400EB5FA4 /* DetailControllerHeaderSectionController.swift in Sources */,
 				EE11414224E85E2F004C35F5 /* SearchBarModel.swift in Sources */,
 				EE11414424E85F35004C35F5 /* SearchBarCell.swift in Sources */,
+				3A4F39F726108D3000B03C59 /* SectionDividerCell.swift in Sources */,
 				0CB3BF762232BCC400A5B371 /* FormLinkCell.swift in Sources */,
 				EE1BC56424967CF4004DD427 /* AvailabilityInfoModel.swift in Sources */,
 				3C9D93B224E85A0C000C27A6 /* MenuHeaderCell.swift in Sources */,
+				3A4F39F226108CF000B03C59 /* SectionDividerModel.swift in Sources */,
 				EE4C803F24A5FDCE00EB5FA4 /* DetailControllerHeaderCell.swift in Sources */,
 				0CA3F4F62173EEBE00988A46 /* UIColor+Extension.swift in Sources */,
+				3A4F39E826108C5500B03C59 /* ActivityView.swift in Sources */,
 				EEA41181249E85C700190A30 /* AvailabilityHeaderSectionController.swift in Sources */,
 				0C8B6D5F2232436600058AE6 /* SpaceModel.swift in Sources */,
 				081E43702380B4B1001D0485 /* MealsFilterSectionController.swift in Sources */,
@@ -757,6 +772,7 @@
 				0C5D0C0B21827F9C00060874 /* UIFont+Extension.swift in Sources */,
 				0C8B6D612232441C00058AE6 /* CurrentDensityModel.swift in Sources */,
 				3CA57843257C8FE90081E16B /* FeedbackQuestion.swift in Sources */,
+				3A4F39ED26108CAA00B03C59 /* SectionDividerSectionController.swift in Sources */,
 				0C316AD52223773400AE4BE3 /* Utils.swift in Sources */,
 				EEED3D2823F86C7C000E0220 /* GymDensitySectionController.swift in Sources */,
 				0C8B6D6E22324C3400058AE6 /* SpaceSectionController.swift in Sources */,

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -34,6 +34,8 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             self.mealList = meals
 
             if !meals.contains(selectedMeal) && meals.count > 0 {
+                print("you are here")
+                unavailableLabel.isHidden = true
                 let currentTime = Int(Date().timeIntervalSince1970)
                 print("Current Time: \(currentTime)")
                 selectedMeal = meals[0]
@@ -46,8 +48,18 @@ extension PlaceDetailViewController: ListAdapterDataSource {
                         print("\(currentTime) > \(endTime) at index \(index), which is \(meals[index])")
                     }
                 }
+            } else if meals.count == 0 {
+                unavailableLabel.isHidden = false
+                view.addSubview(unavailableLabel)
             }
         }
+        //if there are not any available menus for the day, the unavailable menu label is shown else it is hidden and the activity indicator spins until the menus load
+        else if place.menus.weeksMenus.count == 0 {
+            spinnerView.isHidden = false
+            spinnerView.animate()
+            view.addSubview(spinnerView)
+        }
+
         return [
             DetailControllerHeaderModel(displayName: place.displayName, hours: place.hours),
             SpaceModel(space: Constants.smallPadding),
@@ -59,12 +71,15 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             SpaceModel(space: linkTopOffset),
             FormLinkModel(isClosed: place.isClosed, waitTime: place.waitTime),
             SpaceModel(space: Constants.mediumPadding),
+            SectionDividerModel(lineWidth: dividerHeight),
+            SpaceModel(space: Constants.mediumPadding),
+            MenuHeaderModel(),
+            SpaceModel(space: Constants.mlPadding),
             DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays),
             SpaceModel(space: Constants.smallPadding),
-            MenuHeaderModel(),
-            SpaceModel(space: Constants.smallPadding),
             MealFiltersModel(meals: meals, selectedMeal: selectedMeal),
-            SpaceModel(space: Constants.smallPadding),
+            SectionDividerModel(lineWidth: dividerHeight),
+            SpaceModel(space: Constants.mediumPadding),
             MenuModel(menu: menus, mealNames: meals, selectedMeal: selectedMeal),
             SpaceModel(space: Constants.smallPadding)
         ]
@@ -74,6 +89,9 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         if object is SpaceModel {
             let spaceModel = object as! SpaceModel
             return SpaceSectionController(spaceModel: spaceModel)
+        } else if object is SectionDividerModel {
+            let sectionDividerModel = object as! SectionDividerModel
+            return SectionDividerSectionController(sectionDividerModel: sectionDividerModel)
         } else if object is CurrentDensityModel {
             let currentDensityModel = object as! CurrentDensityModel
             return CurrentDensitySectionController(currentDensityModel: currentDensityModel)

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -33,9 +33,15 @@ extension PlaceDetailViewController: ListAdapterDataSource {
 
             self.mealList = meals
 
-            if !meals.contains(selectedMeal) && meals.count > 0 {
-                print("you are here")
+            if meals.count > 0 {
+                spinnerView.isHidden = true
                 unavailableLabel.isHidden = true
+            } else {
+                unavailableLabel.isHidden = false
+                view.addSubview(unavailableLabel)
+            }
+
+            if !meals.contains(selectedMeal) && meals.count > 0 {
                 let currentTime = Int(Date().timeIntervalSince1970)
                 print("Current Time: \(currentTime)")
                 selectedMeal = meals[0]
@@ -48,16 +54,17 @@ extension PlaceDetailViewController: ListAdapterDataSource {
                         print("\(currentTime) > \(endTime) at index \(index), which is \(meals[index])")
                     }
                 }
-            } else if meals.count == 0 {
-                unavailableLabel.isHidden = false
-                view.addSubview(unavailableLabel)
             }
         }
+
         //if there are not any available menus for the day, the unavailable menu label is shown else it is hidden and the activity indicator spins until the menus load
         else if place.menus.weeksMenus.count == 0 {
             spinnerView.isHidden = false
             spinnerView.animate()
             view.addSubview(spinnerView)
+        } else {
+            unavailableLabel.isHidden = false
+            view.addSubview(unavailableLabel)
         }
 
         return [

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -25,6 +25,7 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
 
     // MARK: - Data vars
     var place: Place!
+    var unavailableLabel: UILabel!
     var selectedWeekday: Int = 0
     var selectedHour: Int = 0
     var mealList = [Meal]()
@@ -39,11 +40,16 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
     // MARK: - View vars
     var collectionView: UICollectionView!
     var loadingBarsView: LoadingBarsView!
+    var spinnerView: ActivityView!
     var feedbackViewController: FeedbackViewController!
 
     // MARK: - Constants
     let largeLoadingBarsLength: CGFloat = 63
     let linkTopOffset: CGFloat = 5
+    let spinnerHeight: CGFloat = 25
+    let dividerHeight: CGFloat = 1
+    let spinnerY: CGFloat = 626 //calculated programmatically using menu y value
+    let unavailableText = "No menus available"
     let ithacaTime = TimeZone(identifier: "America/New_York")!
     var ithacaCalendar = Calendar.current
 
@@ -69,11 +75,34 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
             make.center.equalToSuperview()
         }
 
+        spinnerView = ActivityView()
+        view.addSubview(spinnerView)
+
+        spinnerView.snp.makeConstraints { make in
+            make.width.height.equalTo(spinnerHeight)
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(spinnerY)
+        }
+
+        unavailableLabel = UILabel()
+        unavailableLabel.textColor = .warmGray
+        unavailableLabel.font = .eighteenBold
+        unavailableLabel.text = unavailableText
+        unavailableLabel.isHidden = true
+        view.addSubview(unavailableLabel)
+
+        unavailableLabel.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalTo(spinnerY)
+        }
+
         ithacaCalendar.timeZone = ithacaTime
 
         if place.hours.isEmpty {
             loadingBarsView.isHidden = false
             loadingBarsView.startAnimating()
+            spinnerView.isHidden = true
+            unavailableLabel.isHidden = true
             getHours()
         } else {
             loadingBarsView.removeFromSuperview()

--- a/Campus Density/DiningCells/AvailabilityHeaderCell.swift
+++ b/Campus Density/DiningCells/AvailabilityHeaderCell.swift
@@ -14,7 +14,7 @@ class AvailabilityHeaderCell: UICollectionViewCell {
     var headerLabel: UILabel!
 
     // MARK: - Constants
-    let headerLabelText = "Availability"
+    let headerLabelText = "Current Availability"
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -23,7 +23,7 @@ class AvailabilityHeaderCell: UICollectionViewCell {
         headerLabel.text = headerLabelText
         headerLabel.textColor = .black
         headerLabel.textAlignment = .left
-        headerLabel.font = .thirtyBold
+        headerLabel.font = .twentyFiveBold
         addSubview(headerLabel)
 
         setupConstraints()

--- a/Campus Density/DiningCells/DaySelectionCell.swift
+++ b/Campus Density/DiningCells/DaySelectionCell.swift
@@ -54,8 +54,8 @@ class DaySelectionCell: UICollectionViewCell {
             paragraphStyle.alignment = .center
             var textColor = UIColor.warmGray
             if button.tag == selectedWeekday {
-                textColor = .grayishBrown
-                button.layer.borderColor = UIColor.warmGray.cgColor
+                textColor = .densityGreen
+                button.layer.borderColor = UIColor.densityGreen.cgColor
                 button.layer.borderWidth = 1
             }
             let title = NSMutableAttributedString(string: weekdayAbbreviation(weekday: button.tag), attributes: [.foregroundColor: textColor, .font: UIFont.sixteen, .paragraphStyle: paragraphStyle])

--- a/Campus Density/DiningCells/MealFilterCell.swift
+++ b/Campus Density/DiningCells/MealFilterCell.swift
@@ -20,6 +20,7 @@ class MealFilterCell: UICollectionViewCell {
 
     // MARK: - View vars
     var filterButtons = [UIButton]()
+    var lineView: UIView!
 
     // MARK: - Constants
     let labelHorizontalPadding: CGFloat = 10
@@ -45,18 +46,24 @@ class MealFilterCell: UICollectionViewCell {
     }
 
     func setupConstraints() {
-        let padding: CGFloat = Constants.smallPadding
-        var index: Int = 0
-        var buttonLeftOffset: CGFloat = padding
-        filterButtons.forEach { button in
-            let buttonWidth = mealLabel(meal: mealModel.meals[index]).widthWithConstrainedHeight(frame.height, font: .sixteen) + labelHorizontalPadding * 2
-            button.snp.makeConstraints({ make in
+        var buttonLeftOffset: CGFloat = 0
+        let numOfMeals: CGFloat = CGFloat(filterButtons.count)
+        let buttonWidth = frame.width / numOfMeals
+        let sliderHeight = buttonHeight
+        for (meal, button) in zip(mealModel.meals, filterButtons) {
+            button.snp.makeConstraints { make in
                 make.width.equalTo(buttonWidth)
                 make.height.equalTo(buttonHeight)
                 make.left.equalToSuperview().offset(buttonLeftOffset)
-            })
-            index += 1
-            buttonLeftOffset += buttonWidth + padding
+            }
+            if meal == mealModel.selectedMeal {
+                lineView = UIView(frame: CGRect(x: buttonLeftOffset, y: sliderHeight, width: buttonWidth, height: 2))
+                lineView.backgroundColor = .densityGreen
+                lineView.layer.borderColor = UIColor.densityGreen.cgColor
+                lineView.layer.borderWidth = 1
+                contentView.addSubview(lineView)
+            }
+            buttonLeftOffset += buttonWidth
         }
     }
 
@@ -73,16 +80,14 @@ class MealFilterCell: UICollectionViewCell {
             let button = UIButton()
             button.tag = index
             button.setTitle(mealLabel(meal: meal), for: .normal)
-            button.titleLabel?.font = .sixteen
+            button.titleLabel?.font = .eighteen
             button.setTitleColor(.warmGray, for: .normal)
             button.clipsToBounds = true
             if meal == mealModel.selectedMeal {
-                button.setTitleColor(.grayishBrown, for: .normal)
-                button.layer.borderColor = UIColor.warmGray.cgColor
-                button.layer.borderWidth = 1
+                button.setTitleColor(.densityGreen, for: .normal)
+                button.titleLabel?.font = .eighteenBold
             }
-            button.layer.cornerRadius = 10
-            button.addTarget(self, action: #selector(filterButtonPressed), for: .touchUpInside)
+            button.addTarget(self, action: #selector(filterButtonPressed), for: .primaryActionTriggered)
             contentView.addSubview(button)
             self.filterButtons.append(button)
         }

--- a/Campus Density/DiningCells/MenuCell.swift
+++ b/Campus Density/DiningCells/MenuCell.swift
@@ -12,7 +12,6 @@ class MenuCell: UICollectionViewCell {
 
     // MARK: - View vars
     var menuCollectionView: UICollectionView!
-    var unavailableLabel: UILabel!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -27,11 +26,6 @@ class MenuCell: UICollectionViewCell {
         menuCollectionView.isPagingEnabled = true
         menuCollectionView.showsHorizontalScrollIndicator = false
         contentView.addSubview(menuCollectionView)
-        unavailableLabel = UILabel()
-        unavailableLabel.textColor = .warmGray
-        unavailableLabel.font = .eighteenBold
-        unavailableLabel.text = "No menus available"
-        contentView.addSubview(unavailableLabel)
     }
 
     func setupConstraints() {
@@ -39,15 +33,10 @@ class MenuCell: UICollectionViewCell {
             make.width.equalToSuperview()
             make.height.equalToSuperview()
         }
-        unavailableLabel.snp.makeConstraints { make in
-            make.height.equalToSuperview()
-            make.centerX.equalToSuperview()
-        }
     }
 
     func configure(dataSource: UICollectionViewDataSource, selected: Int, delegate: UICollectionViewDelegate) {
         menuCollectionView.isHidden = false
-        unavailableLabel.isHidden = true
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.itemSize = self.frame.size
@@ -62,7 +51,6 @@ class MenuCell: UICollectionViewCell {
 
     func configureAsNoMenus() {
         menuCollectionView.isHidden = true
-        unavailableLabel.isHidden = false
         setupConstraints()
     }
 

--- a/Campus Density/DiningCells/MenuHeaderCell.swift
+++ b/Campus Density/DiningCells/MenuHeaderCell.swift
@@ -12,9 +12,12 @@ class MenuHeaderCell: UICollectionViewCell {
 
     // MARK: - View vars
     var headerLabel: UILabel!
+    var detailsLabel: UILabel!
 
     // MARK: - Constants
-    let headerLabelText = "Menu"
+    let headerLabelText = "Menus & Hours"
+    let detailsLabelText = "Show Details For:"
+    let spacing = 5
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -23,8 +26,15 @@ class MenuHeaderCell: UICollectionViewCell {
         headerLabel.text = headerLabelText
         headerLabel.textColor = .black
         headerLabel.textAlignment = .left
-        headerLabel.font = .thirtyBold
+        headerLabel.font = .twentyFiveBold
         addSubview(headerLabel)
+
+        detailsLabel = UILabel()
+        detailsLabel.text = detailsLabelText
+        detailsLabel.textColor = .warmGray
+        detailsLabel.textAlignment = .left
+        detailsLabel.font = .sixteen
+        addSubview(detailsLabel)
 
         setupConstraints()
     }
@@ -32,10 +42,19 @@ class MenuHeaderCell: UICollectionViewCell {
     func setupConstraints() {
         let headerLabelTextHeight = headerLabelText.height(withConstrainedWidth: frame.width - Constants.smallPadding * 2, font: headerLabel.font)
 
+        let detailsLabelTextHeight = detailsLabelText.height(withConstrainedWidth: frame.width - Constants.smallPadding * 2, font: detailsLabel.font)
+
         headerLabel.snp.makeConstraints { make in
             make.width.equalToSuperview().inset(Constants.smallPadding)
             make.left.equalToSuperview().offset(Constants.smallPadding)
             make.height.equalTo(headerLabelTextHeight)
+        }
+
+        detailsLabel.snp.makeConstraints { make in
+            make.width.equalToSuperview().inset(Constants.smallPadding)
+            make.left.equalToSuperview().offset(Constants.smallPadding)
+            make.height.equalTo(detailsLabelTextHeight)
+            make.top.equalTo(headerLabel.snp.bottom).offset(spacing)
         }
     }
 

--- a/Campus Density/DiningCells/MenuInteriorCell.swift
+++ b/Campus Density/DiningCells/MenuInteriorCell.swift
@@ -53,7 +53,7 @@ class MenuInteriorCell: UICollectionViewCell {
         clockImageView.image = UIImage(named: "clock")
         contentView.addSubview(clockImageView)
         hoursLabel = UILabel()
-        hoursLabel.font = .eighteenBold
+        hoursLabel.font = .sixteenBold
         hoursLabel.textColor = .black
         contentView.addSubview(hoursLabel)
         menuLabel = UILabel()
@@ -84,7 +84,7 @@ class MenuInteriorCell: UICollectionViewCell {
                 res.append(newLine)
             }
             let categoryString = NSMutableAttributedString(string: station.category)
-            categoryString.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.grayishBrown, NSAttributedString.Key.font: UIFont.eighteenBold], range: NSRange(location: 0, length: categoryString.length))
+            categoryString.addAttributes([NSAttributedString.Key.foregroundColor: UIColor.grayishBrown, NSAttributedString.Key.font: UIFont.sixteenBold], range: NSRange(location: 0, length: categoryString.length))
             res.append(categoryString)
             let itemString = NSMutableAttributedString()
             for item in station.items {

--- a/Campus Density/DiningCells/SectionDividerCell.swift
+++ b/Campus Density/DiningCells/SectionDividerCell.swift
@@ -1,0 +1,34 @@
+//
+//  SectionDividerCell.swift
+//  Campus Density
+//
+//  Created by Mihikaa Goenka on 28/03/21.
+//  Copyright © 2021 Cornell DTI. All rights reserved.
+//
+
+import UIKit
+
+class SectionDividerCell: UICollectionViewCell {
+
+    // MARK: - View vars
+    var line: UIView!
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        line = UIView()
+        line.backgroundColor = .densityLightGray
+        addSubview(line)
+
+        line.snp.makeConstraints { make in
+            make.width.height.equalToSuperview()
+            make.center.equalToSuperview()
+        }
+
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/Campus Density/DiningModels/SectionDividerModel.swift
+++ b/Campus Density/DiningModels/SectionDividerModel.swift
@@ -1,0 +1,35 @@
+//
+//  SectionDividerModel.swift
+//  Campus Density
+//
+//  Created by Mihikaa Goenka on 28/03/21.
+//  Copyright © 2021 Cornell DTI. All rights reserved.
+//
+
+import Foundation
+import IGListKit
+
+class SectionDividerModel {
+
+    var lineWidth: CGFloat
+    let identifier = UUID().uuidString
+
+    init(lineWidth: CGFloat) {
+        self.lineWidth = lineWidth
+    }
+
+}
+
+extension SectionDividerModel: ListDiffable {
+
+    func diffIdentifier() -> NSObjectProtocol {
+        return identifier as NSString
+    }
+
+    func isEqual(toDiffableObject object: ListDiffable?) -> Bool {
+        if self === object { return true }
+        guard let object = object as? SectionDividerModel else { return false }
+        return object.identifier == identifier
+    }
+
+}

--- a/Campus Density/SectionControllers/SectionDividerSectionController.swift
+++ b/Campus Density/SectionControllers/SectionDividerSectionController.swift
@@ -1,0 +1,34 @@
+//
+//  SectionDividerSectionController.swift
+//  Campus Density
+//
+//  Created by Mihikaa Goenka on 28/03/21.
+//  Copyright © 2021 Cornell DTI. All rights reserved.
+//
+
+import Foundation
+import IGListKit
+
+class SectionDividerSectionController: ListSectionController {
+
+    // MARK: - Data vars
+    var sectionDividerModel: SectionDividerModel!
+
+    init(sectionDividerModel: SectionDividerModel) {
+        self.sectionDividerModel = sectionDividerModel
+    }
+
+    override func sizeForItem(at index: Int) -> CGSize {
+        guard let containerSize = collectionContext?.containerSize else { return .zero }
+        return CGSize(width: containerSize.width, height: sectionDividerModel.lineWidth)
+    }
+
+    override func cellForItem(at index: Int) -> UICollectionViewCell {
+        return collectionContext?.dequeueReusableCell(of: SectionDividerCell.self, for: self, at: index) as! SectionDividerCell
+    }
+
+    override func didUpdate(to object: Any) {
+        sectionDividerModel = object as? SectionDividerModel
+    }
+
+}

--- a/Campus Density/Utils.swift
+++ b/Campus Density/Utils.swift
@@ -11,6 +11,7 @@ import UIKit
 struct Constants {
     static let smallPadding: CGFloat = 15
     static let mediumPadding: CGFloat = 25
+    static let mlPadding: CGFloat = 40
     static let largePadding: CGFloat = 50
 }
 

--- a/Campus Density/Views/ActivityView.swift
+++ b/Campus Density/Views/ActivityView.swift
@@ -1,0 +1,47 @@
+//
+//  ActivityView.swift
+//  Campus Density
+//
+//  Created by Mihikaa Goenka on 28/03/21.
+//  Copyright © 2021 Cornell DTI. All rights reserved.
+//
+
+import UIKit
+
+class ActivityView: UIView {
+
+    let loadingCircle = CAShapeLayer()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        /* create an activity indicator for when the menu data hasn't loaded */
+        self.frame = CGRect(x: 0, y: 0, width: 36, height: 36)
+        let outline = self.bounds
+        let path = UIBezierPath(ovalIn: outline)
+        loadingCircle.path = path.cgPath
+        loadingCircle.lineWidth = 3
+        loadingCircle.strokeEnd = 0.45
+        loadingCircle.lineCap = .round
+
+        loadingCircle.strokeColor = UIColor.black.cgColor
+        loadingCircle.fillColor = UIColor.clear.cgColor
+        self.layer.addSublayer(loadingCircle)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /* animate the loading circle by calling this function*/
+    func animate() {
+        UIView.animate(withDuration: 1, delay: 0, options: .curveLinear, animations: {
+            self.transform = CGAffineTransform(rotationAngle: .pi)
+        }) { (_) in
+            UIView.animate(withDuration: 1, delay: 0, options: .curveLinear, animations: {self.transform = CGAffineTransform(rotationAngle: 0)
+            }) { (_) in
+                self.animate()
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request updates the interface for the menu filters according to the Figma design and fixes a bug that was encountered that caused the "No menus available" label to appear in the little delay before menus had loaded for facilities that had available menus for the day. This might have been due to a possible lag in fetching the data from the backend. The view was initially being rendered before the data was fetched. When the user enters a dining facility, they are able to swipe across the various filters for breakfast, lunch and dinner (or brunch etc.) and view the menu options. They can even click on the various meal categories to switch for one meal to another. While these menus load, an activity indicator I coded up is shown (not the default iOS indicator since the idea was to make it consistent with Android) and if there are no menus available, a label indicating the same is displayed in place of the menus. I wrote the code for the same on the same level as the collection view that contains the main part of the app to prevent the lag and to ensure consistency with the loading bars view. There was a second bug that was encountered that caused No menus available to appear as an overlay on some dining halls that had meals available on only certain days and this pull request fixes those bugs.

- [x] created an activity indicator view 
- [x] created a slider to indicate which menu filter is active
- [x] fixed bugs

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->
<img src="https://user-images.githubusercontent.com/71369151/112750768-7d9a5780-8f98-11eb-8d36-f634c151ec7c.png" width="400" height="700">
<img src="https://user-images.githubusercontent.com/71369151/112750790-99056280-8f98-11eb-87eb-b85b766bd595.png" width="400" height="700">
<img src="https://user-images.githubusercontent.com/71369151/112750794-a7ec1500-8f98-11eb-829a-205005c61490.png" width="400" height="700">

### To Do

- [ ] static menus for cafes
- [ ] develop better testing mechanisms to ensure that there are no bugs



