### PR TITLE
Cafe menus

### DIFF
--- a/Campus Density.xcodeproj/project.pbxproj
+++ b/Campus Density.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		3C29547D25856E6F00965D9A /* AccuracyQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29547C25856E6F00965D9A /* AccuracyQuestion.swift */; };
 		3C29548525856EDE00965D9A /* ObservedDensityQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29548425856EDE00965D9A /* ObservedDensityQuestion.swift */; };
 		3C29548A25858D0200965D9A /* WaitTimeQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C29548925858D0200965D9A /* WaitTimeQuestion.swift */; };
+		3C3839542625155D00DD6250 /* CafeMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C3839532625155D00DD6250 /* CafeMenuCell.swift */; };
 		3C722EE42606938400E1DCFA /* PlaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C722EE32606938400E1DCFA /* PlaceModel.swift */; };
 		3C755EAC2586B93500C7FFC5 /* CommentQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C755EAB2586B93500C7FFC5 /* CommentQuestion.swift */; };
 		3C7A4E642586C9C600676980 /* ThanksQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A4E632586C9C600676980 /* ThanksQuestion.swift */; };
@@ -174,6 +175,7 @@
 		3C29547C25856E6F00965D9A /* AccuracyQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccuracyQuestion.swift; sourceTree = "<group>"; };
 		3C29548425856EDE00965D9A /* ObservedDensityQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservedDensityQuestion.swift; sourceTree = "<group>"; };
 		3C29548925858D0200965D9A /* WaitTimeQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaitTimeQuestion.swift; sourceTree = "<group>"; };
+		3C3839532625155D00DD6250 /* CafeMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CafeMenuCell.swift; sourceTree = "<group>"; };
 		3C722EE32606938400E1DCFA /* PlaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceModel.swift; sourceTree = "<group>"; };
 		3C755EAB2586B93500C7FFC5 /* CommentQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentQuestion.swift; sourceTree = "<group>"; };
 		3C7A4E632586C9C600676980 /* ThanksQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThanksQuestion.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 				3CD56C8C24AEB21A004D4910 /* LastUpdatedTextCell.swift */,
 				EE11414324E85F35004C35F5 /* SearchBarCell.swift */,
 				EE0DEF7C251509A2001632C5 /* PoliciesCell.swift */,
+				3C3839532625155D00DD6250 /* CafeMenuCell.swift */,
 			);
 			path = DiningCells;
 			sourceTree = "<group>";
@@ -729,6 +732,7 @@
 				3C29548A25858D0200965D9A /* WaitTimeQuestion.swift in Sources */,
 				0C209B0F224823560007AFA9 /* LogoModel.swift in Sources */,
 				EE64E0DB240B0DAC003E449E /* GymFilterCell.swift in Sources */,
+				3C3839542625155D00DD6250 /* CafeMenuCell.swift in Sources */,
 				EE93BF1A2380A89F00219902 /* MealFiltersModel.swift in Sources */,
 				EEA4117F249E849100190A30 /* AvailabilityHeaderModel.swift in Sources */,
 				3C755EAC2586B93500C7FFC5 /* CommentQuestion.swift in Sources */,

--- a/Campus Density.xcodeproj/project.pbxproj
+++ b/Campus Density.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		081E43702380B4B1001D0485 /* MealsFilterSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081E436F2380B4B1001D0485 /* MealsFilterSectionController.swift */; };
-		08F679802378E7BA005B7810 /* MenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6797F2378E7BA005B7810 /* MenuCell.swift */; };
+		08F679802378E7BA005B7810 /* DiningHallMenuCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F6797F2378E7BA005B7810 /* DiningHallMenuCell.swift */; };
 		08F679822378E8D7005B7810 /* MenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F679812378E8D7005B7810 /* MenuModel.swift */; };
 		08F679842378E976005B7810 /* MenuSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F679832378E976005B7810 /* MenuSectionController.swift */; };
 		0C209B0F224823560007AFA9 /* LogoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C209B0E224823560007AFA9 /* LogoModel.swift */; };
@@ -58,7 +58,7 @@
 		3C722EE42606938400E1DCFA /* PlaceModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C722EE32606938400E1DCFA /* PlaceModel.swift */; };
 		3C755EAC2586B93500C7FFC5 /* CommentQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C755EAB2586B93500C7FFC5 /* CommentQuestion.swift */; };
 		3C7A4E642586C9C600676980 /* ThanksQuestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7A4E632586C9C600676980 /* ThanksQuestion.swift */; };
-		3C8008E9240B3EAF004DD1DB /* MenuInteriorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8008E8240B3EAF004DD1DB /* MenuInteriorCell.swift */; };
+		3C8008E9240B3EAF004DD1DB /* DiningHallMenuInteriorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C8008E8240B3EAF004DD1DB /* DiningHallMenuInteriorCell.swift */; };
 		3C873289244218CA00D42F59 /* GraphHeaderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C873288244218CA00D42F59 /* GraphHeaderCell.swift */; };
 		3C87328B244218EE00D42F59 /* GraphHeaderSectionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87328A244218EE00D42F59 /* GraphHeaderSectionController.swift */; };
 		3C87328D244219B000D42F59 /* GraphHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C87328C244219B000D42F59 /* GraphHeaderModel.swift */; };
@@ -122,7 +122,7 @@
 
 /* Begin PBXFileReference section */
 		081E436F2380B4B1001D0485 /* MealsFilterSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MealsFilterSectionController.swift; sourceTree = "<group>"; };
-		08F6797F2378E7BA005B7810 /* MenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuCell.swift; sourceTree = "<group>"; };
+		08F6797F2378E7BA005B7810 /* DiningHallMenuCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHallMenuCell.swift; sourceTree = "<group>"; };
 		08F679812378E8D7005B7810 /* MenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuModel.swift; sourceTree = "<group>"; };
 		08F679832378E976005B7810 /* MenuSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSectionController.swift; sourceTree = "<group>"; };
 		0C209B0E224823560007AFA9 /* LogoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogoModel.swift; sourceTree = "<group>"; };
@@ -177,7 +177,7 @@
 		3C722EE32606938400E1DCFA /* PlaceModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceModel.swift; sourceTree = "<group>"; };
 		3C755EAB2586B93500C7FFC5 /* CommentQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentQuestion.swift; sourceTree = "<group>"; };
 		3C7A4E632586C9C600676980 /* ThanksQuestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThanksQuestion.swift; sourceTree = "<group>"; };
-		3C8008E8240B3EAF004DD1DB /* MenuInteriorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuInteriorCell.swift; sourceTree = "<group>"; };
+		3C8008E8240B3EAF004DD1DB /* DiningHallMenuInteriorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiningHallMenuInteriorCell.swift; sourceTree = "<group>"; };
 		3C873288244218CA00D42F59 /* GraphHeaderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderCell.swift; sourceTree = "<group>"; };
 		3C87328A244218EE00D42F59 /* GraphHeaderSectionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderSectionController.swift; sourceTree = "<group>"; };
 		3C87328C244219B000D42F59 /* GraphHeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphHeaderModel.swift; sourceTree = "<group>"; };
@@ -400,9 +400,9 @@
 				0CB3BF7D2232C50D00A5B371 /* GraphCell.swift */,
 				0C209B12224825AF0007AFA9 /* PlaceCell.swift */,
 				0C209B16224829280007AFA9 /* LogoCell.swift */,
-				08F6797F2378E7BA005B7810 /* MenuCell.swift */,
+				08F6797F2378E7BA005B7810 /* DiningHallMenuCell.swift */,
 				EE93BF172380A44300219902 /* MealFilterCell.swift */,
-				3C8008E8240B3EAF004DD1DB /* MenuInteriorCell.swift */,
+				3C8008E8240B3EAF004DD1DB /* DiningHallMenuInteriorCell.swift */,
 				3C873288244218CA00D42F59 /* GraphHeaderCell.swift */,
 				EEA4117C249E841200190A30 /* AvailabilityHeaderCell.swift */,
 				3C9D93B124E85A0C000C27A6 /* MenuHeaderCell.swift */,
@@ -758,11 +758,11 @@
 				0C8B6D63223244B700058AE6 /* FormLinkModel.swift in Sources */,
 				0C8B6D652232459900058AE6 /* DaySelectionModel.swift in Sources */,
 				3C9D93B424E85BDF000C27A6 /* MenuHeaderSectionController.swift in Sources */,
-				3C8008E9240B3EAF004DD1DB /* MenuInteriorCell.swift in Sources */,
+				3C8008E9240B3EAF004DD1DB /* DiningHallMenuInteriorCell.swift in Sources */,
 				3CDC62C02577440B005083C2 /* FeedbackViewController.swift in Sources */,
 				0CA3F4C02173EA8000988A46 /* AppDelegate.swift in Sources */,
 				0C8B6D6722324A7A00058AE6 /* GraphModel.swift in Sources */,
-				08F679802378E7BA005B7810 /* MenuCell.swift in Sources */,
+				08F679802378E7BA005B7810 /* DiningHallMenuCell.swift in Sources */,
 				0C209B11224824250007AFA9 /* PlaceSectionController.swift in Sources */,
 				0CB3BF742232BC4A00A5B371 /* FormLinkSectionController.swift in Sources */,
 				EE9BED4C23F4B7ED00A37464 /* GymDensityModel.swift in Sources */,

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -187,9 +187,9 @@ struct MenuData: Codable {
     /// The meal description, e.g. "Lunch"
     var description: String
     /// The absolute start time of this meal, in Unix time
-    var startTime: Int
+    var startTime: Double
     /// The absolute end time of this meal, in Unix time
-    var endTime: Int
+    var endTime: Double
 }
 
 /// All menu data for a dining hall on a particular day.
@@ -441,7 +441,6 @@ class API {
                                     return place.id == menu.id
                                 })
                                 guard let placeIndex = index else { return }
-                                print(menu.weeksMenus)
                                 System.places[placeIndex].cafeMenus = menu.weeksMenus
                                 System.places[placeIndex].facilityType = .cafe
                             })

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -95,7 +95,7 @@ class Place {
     var hours: [DailyInfo]
     var history: [String: [String: Double]]
     var region: Region
-    var menus: WeekMenus
+    var diningMenus: [DayMenus]?
 
     /// Initilizes a new Place object with the eatety's display name, it's corresponding FIrebase id, its `Density`, whether it is closed or not, its hours, history, location and its week's menus.
     ///
@@ -108,7 +108,7 @@ class Place {
     ///   - history: TODO
     ///   - region: A `Region` instance specifying where this object is located on campus
     ///   - menus: A `WeekMenus` instance representing all the menus for this eatery for the entire week, starting from today.
-    init(displayName: String, id: String, density: Density, waitTime: Double?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, menus: WeekMenus) {
+    init(displayName: String, id: String, density: Density, waitTime: Double?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, diningMenus: [DayMenus]?) {
         self.displayName = displayName
         self.id = id
         self.density = density
@@ -117,7 +117,7 @@ class Place {
         self.hours = hours
         self.history = history
         self.region = region
-        self.menus = menus
+        self.diningMenus = diningMenus
     }
 
 }
@@ -326,7 +326,7 @@ class API {
                 switch result {
                 case .success(let placeNames):
                     System.places = placeNames.map { placeName in
-                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: nil, isClosed: false, hours: [], history: [:], region: .north, menus: WeekMenus(weeksMenus: [], id: placeName.id))
+                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: nil, isClosed: false, hours: [], history: [:], region: .north, diningMenus: nil)
                     }
                     completion(true)
                 case .failure(let error):
@@ -397,7 +397,7 @@ class API {
                             return place.id == menu.id
                         })
                         guard let placeIndex = index else { return }
-                        System.places[placeIndex].menus = menu
+                        System.places[placeIndex].diningMenus = menu.weeksMenus
                     })
                     completion(true)
 

--- a/Campus Density/API.swift
+++ b/Campus Density/API.swift
@@ -25,6 +25,11 @@ enum Region: String, Codable {
     case west
 }
 
+enum FacilityType: String, Codable {
+    case diningHall = "dining-hall"
+    case cafe = "cafe"
+}
+
 /**
  Represents the information of an eatery's name
  
@@ -95,7 +100,9 @@ class Place {
     var hours: [DailyInfo]
     var history: [String: [String: Double]]
     var region: Region
+    var facilityType: FacilityType!
     var diningMenus: [DayMenus]?
+    var cafeMenus: [String]?
 
     /// Initilizes a new Place object with the eatety's display name, it's corresponding FIrebase id, its `Density`, whether it is closed or not, its hours, history, location and its week's menus.
     ///
@@ -108,7 +115,7 @@ class Place {
     ///   - history: TODO
     ///   - region: A `Region` instance specifying where this object is located on campus
     ///   - menus: A `WeekMenus` instance representing all the menus for this eatery for the entire week, starting from today.
-    init(displayName: String, id: String, density: Density, waitTime: Double?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, diningMenus: [DayMenus]?) {
+    init(displayName: String, id: String, density: Density, waitTime: Double?, isClosed: Bool, hours: [DailyInfo], history: [String: [String: Double]], region: Region, facilityType: FacilityType?, diningMenus: [DayMenus]?, cafeMenus: [String]?) {
         self.displayName = displayName
         self.id = id
         self.density = density
@@ -117,7 +124,9 @@ class Place {
         self.hours = hours
         self.history = history
         self.region = region
+        self.facilityType = facilityType
         self.diningMenus = diningMenus
+        self.cafeMenus = cafeMenus
     }
 
 }
@@ -197,6 +206,17 @@ struct WeekMenus: Codable {
     var weeksMenus: [DayMenus]
     /// Eatery id, e.g. "becker"
     var id: String
+}
+
+/// Static menus for cafe
+struct CafeMenus: Codable {
+    var weeksMenus: [String]
+    var id: String
+}
+
+/// Used to decode if location should use CafeMenus or WeekMenus
+struct CafeOrDiningHall: Codable {
+    var type: FacilityType
 }
 
 struct AddFeedbackResponse: Codable {
@@ -326,7 +346,7 @@ class API {
                 switch result {
                 case .success(let placeNames):
                     System.places = placeNames.map { placeName in
-                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: nil, isClosed: false, hours: [], history: [:], region: .north, diningMenus: nil)
+                        return Place(displayName: placeName.displayName, id: placeName.id, density: .notBusy, waitTime: nil, isClosed: false, hours: [], history: [:], region: .north, facilityType: nil, diningMenus: nil, cafeMenus: nil)
                     }
                     completion(true)
                 case .failure(let error):
@@ -383,26 +403,57 @@ class API {
         print("PLACE: \(place.id)")
 
         let parameters = [
-            "facility": place.id
+            "id": place.id
         ]
 
         AF.request("\(url)/menuData", parameters: parameters, headers: headers)
             .responseData { response in
                 let decoder = JSONDecoder()
-                let result: AFResult<[WeekMenus]> = decoder.decodeResponse(from: response)
-                switch result {
-                case .success(let menulist):
-                    menulist.forEach({menu in
-                        let index = System.places.firstIndex(where: { place -> Bool in
-                            return place.id == menu.id
-                        })
-                        guard let placeIndex = index else { return }
-                        System.places[placeIndex].diningMenus = menu.weeksMenus
-                    })
-                    completion(true)
+                let facilityTypeResult: AFResult<[CafeOrDiningHall]> = decoder.decodeResponse(from: response)
+                switch facilityTypeResult {
+                case .success(let facilityTypeList):
+                    switch facilityTypeList[0].type { // This only fetches menus for one location at a time
 
+                    case .diningHall:
+                        let result: AFResult<[WeekMenus]> = decoder.decodeResponse(from: response)
+                        switch result {
+                        case .success(let menulist):
+                            menulist.forEach({ menu in // Looping... through one element
+                                let index = System.places.firstIndex(where: { place -> Bool in
+                                    return place.id == menu.id
+                                })
+                                guard let placeIndex = index else { return }
+                                System.places[placeIndex].diningMenus = menu.weeksMenus
+                                System.places[placeIndex].facilityType = .diningHall
+                            })
+                            completion(true)
+                        case .failure(let error):
+                            print(error, "menuData failed to decode dining hall style menus")
+                            completion(false)
+                        }
+
+                    case .cafe:
+                        let result: AFResult<[CafeMenus]> = decoder.decodeResponse(from: response)
+                        switch result {
+                        case .success(let menulist):
+                            menulist.forEach({ menu in // Looping... through one element
+                                let index = System.places.firstIndex(where: { place -> Bool in
+                                    return place.id == menu.id
+                                })
+                                guard let placeIndex = index else { return }
+                                print(menu.weeksMenus)
+                                System.places[placeIndex].cafeMenus = menu.weeksMenus
+                                System.places[placeIndex].facilityType = .cafe
+                            })
+                            completion(true)
+                        case .failure(let error):
+                            print(error, "menuData failed to decode cafe style menus")
+                            completion(false)
+                        }
+
+                    }
                 case .failure(let error):
-                    print(error, "menuData")
+                    print(error, "menuData failed to decode cafe or dining hall")
                     completion(false)
                 }
         }

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -95,9 +95,9 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         objects.append(SectionDividerModel(lineWidth: dividerHeight))
         objects.append(SpaceModel(space: Constants.mediumPadding))
         objects.append(MenuHeaderModel())
+        objects.append(SpaceModel(space: Constants.mlPadding))
         switch place.facilityType {
         case .diningHall:
-            objects.append(SpaceModel(space: Constants.mlPadding))
             objects.append(DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays))
             objects.append(SpaceModel(space: Constants.smallPadding))
             objects.append(MealFiltersModel(meals: meals, selectedMeal: selectedMeal))

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -13,83 +13,104 @@ extension PlaceDetailViewController: ListAdapterDataSource {
 
     func objects(for listAdapter: ListAdapter) -> [ListDiffable] {
         let lastUpdatedTime = API.getLastUpdatedDensityTime()
-        var menus = DayMenus(menus: [], date: "help")
-        var menuDay = selectedWeekday + 1 - getCurrentWeekday()
-        if menuDay <= 0 {
-            menuDay = 7 + menuDay
-        }
-        if let diningMenus = place.diningMenus, !diningMenus.isEmpty {
-            menus = diningMenus[menuDay]
-        }
-        var meals = [Meal]()
-        var endTimes = [Int]()
-        if menus.menus.count != 0 {
-            for meal in menus.menus {
-                if meal.menu.count != 0 {
-                    meals.append(Meal(rawValue: meal.description)!)
-                    endTimes.append(meal.endTime)
+
+        var diningHallMenus: DayMenus!
+        var meals: [Meal]!
+
+        switch place.facilityType {
+        case .diningHall:
+            spinnerView.isHidden = true
+            var menuDay = selectedWeekday + 1 - getCurrentWeekday()
+            if menuDay <= 0 {
+                menuDay = 7 + menuDay
+            }
+            guard let diningMenus = place.diningMenus, menuDay < diningMenus.count else {
+                print("This is not supposed to happen during normal operation, not enough menus returned!")
+                unavailableLabel.isHidden = false
+                view.addSubview(unavailableLabel)
+                break
+            }
+            diningHallMenus = diningMenus[menuDay]
+            meals = [Meal]()
+            var endTimes = [Int]()
+            if diningHallMenus.menus.count > 0 {
+                for meal in diningHallMenus.menus {
+                    if meal.menu.count != 0 {
+                        meals.append(Meal(rawValue: meal.description)!)
+                        endTimes.append(meal.endTime)
+                    }
+                }
+
+                if meals.count > 0 {
+                    unavailableLabel.isHidden = true
+                } else {
+                    unavailableLabel.isHidden = false
+                    view.addSubview(unavailableLabel)
+                }
+
+                // Auto-select next meal if none selected/previous selection unavailable for this day
+                if !meals.contains(selectedMeal) && meals.count > 0 {
+                    let currentTime = Int(Date().timeIntervalSince1970)
+                    print("Current Time: \(currentTime)")
+                    selectedMeal = meals[0]
+                    for (index, endTime) in endTimes.enumerated() {
+                        if currentTime < endTime {
+                            print("\(currentTime) < \(endTime) at index \(index), which is \(meals[index]), choosing this")
+                            selectedMeal = meals[index]
+                            break
+                        } else {
+                            print("\(currentTime) > \(endTime) at index \(index), which is \(meals[index])")
+                        }
+                    }
                 }
             }
-
-            self.mealList = meals
-
-            if meals.count > 0 {
-                spinnerView.isHidden = true
-                unavailableLabel.isHidden = true
-            } else {
+            // If there are not any available menus for THIS day, the unavailable menu label is shown
+            else {
                 unavailableLabel.isHidden = false
                 view.addSubview(unavailableLabel)
             }
 
-            if !meals.contains(selectedMeal) && meals.count > 0 {
-                let currentTime = Int(Date().timeIntervalSince1970)
-                print("Current Time: \(currentTime)")
-                selectedMeal = meals[0]
-                for (index, endTime) in endTimes.enumerated() {
-                    if currentTime < endTime {
-                        print("\(currentTime) < \(endTime) at index \(index), which is \(meals[index]), choosing this")
-                        selectedMeal = meals[index]
-                        break
-                    } else {
-                        print("\(currentTime) > \(endTime) at index \(index), which is \(meals[index])")
-                    }
-                }
-            }
-        }
+        case .cafe:
+            spinnerView.isHidden = true
 
-        //if there are not any available menus for the day, the unavailable menu label is shown else it is hidden and the activity indicator spins until the menus load
-        else if place.diningMenus?.count == 0 {
+        // Still waiting on /menuData to complete and return menus and facility type, so show spinner
+        case .none:
             spinnerView.isHidden = false
             spinnerView.animate()
             view.addSubview(spinnerView)
-        } else {
-            unavailableLabel.isHidden = false
-            view.addSubview(unavailableLabel)
         }
 
-        return [
-            DetailControllerHeaderModel(displayName: place.displayName, hours: place.hours),
-            SpaceModel(space: Constants.smallPadding),
-            AvailabilityHeaderModel(),
-            SpaceModel(space: Constants.smallPadding),
-            LastUpdatedTextModel(lastUpdated: lastUpdatedTime),
-            SpaceModel(space: linkTopOffset),
-            AvailabilityInfoModel(place: place), // TODO: look into only passing what's necessary
-            SpaceModel(space: linkTopOffset),
-            FormLinkModel(isClosed: place.isClosed, waitTime: place.waitTime),
-            SpaceModel(space: Constants.mediumPadding),
-            SectionDividerModel(lineWidth: dividerHeight),
-            SpaceModel(space: Constants.mediumPadding),
-            MenuHeaderModel(),
-            SpaceModel(space: Constants.mlPadding),
-            DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays),
-            SpaceModel(space: Constants.smallPadding),
-            MealFiltersModel(meals: meals, selectedMeal: selectedMeal),
-            SectionDividerModel(lineWidth: dividerHeight),
-            SpaceModel(space: Constants.mediumPadding),
-            MenuModel(menu: menus, mealNames: meals, selectedMeal: selectedMeal),
-            SpaceModel(space: Constants.smallPadding)
-        ]
+        var objects = [ListDiffable]()
+
+        objects.append(DetailControllerHeaderModel(displayName: place.displayName, hours: place.hours))
+        objects.append(SpaceModel(space: Constants.smallPadding))
+        objects.append(AvailabilityHeaderModel())
+        objects.append(SpaceModel(space: Constants.smallPadding))
+        objects.append(LastUpdatedTextModel(lastUpdated: lastUpdatedTime))
+        objects.append(SpaceModel(space: linkTopOffset))
+        objects.append(AvailabilityInfoModel(place: place)) // TODO: look into only passing what's necessary
+        objects.append(SpaceModel(space: linkTopOffset))
+        objects.append(FormLinkModel(isClosed: place.isClosed, waitTime: place.waitTime))
+        objects.append(SpaceModel(space: Constants.mediumPadding))
+        objects.append(SectionDividerModel(lineWidth: dividerHeight))
+        objects.append(SpaceModel(space: Constants.mediumPadding))
+        objects.append(MenuHeaderModel())
+        switch place.facilityType {
+        case .diningHall:
+            objects.append(SpaceModel(space: Constants.mlPadding))
+            objects.append(DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays))
+            objects.append(SpaceModel(space: Constants.smallPadding))
+            objects.append(MealFiltersModel(meals: meals, selectedMeal: selectedMeal))
+            objects.append(SectionDividerModel(lineWidth: dividerHeight))
+            objects.append(SpaceModel(space: Constants.mediumPadding))
+            objects.append(MenuModel(menu: diningHallMenus, mealNames: meals, selectedMeal: selectedMeal))
+        case .cafe:
+            break
+        case .none:
+            break
+        }
+        objects.append(SpaceModel(space: Constants.smallPadding))
+        return objects
     }
 
     func listAdapter(_ listAdapter: ListAdapter, sectionControllerFor object: Any) -> ListSectionController {

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -103,9 +103,9 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             objects.append(MealFiltersModel(meals: meals, selectedMeal: selectedMeal))
             objects.append(SectionDividerModel(lineWidth: dividerHeight))
             objects.append(SpaceModel(space: Constants.mediumPadding))
-            objects.append(MenuModel(menu: diningHallMenus, mealNames: meals, selectedMeal: selectedMeal))
+            objects.append(MenuModel(diningHallMenu: diningHallMenus, mealNames: meals, selectedMeal: selectedMeal))
         case .cafe:
-            break
+            objects.append(MenuModel(cafeMenu: place.cafeMenus!))
         case .none:
             break
         }

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -18,8 +18,8 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         if menuDay <= 0 {
             menuDay = 7 + menuDay
         }
-        if place.menus.weeksMenus.count != 0 {
-            menus = place.menus.weeksMenus[menuDay]
+        if let diningMenus = place.diningMenus, !diningMenus.isEmpty {
+            menus = diningMenus[menuDay]
         }
         var meals = [Meal]()
         var endTimes = [Int]()
@@ -58,7 +58,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         }
 
         //if there are not any available menus for the day, the unavailable menu label is shown else it is hidden and the activity indicator spins until the menus load
-        else if place.menus.weeksMenus.count == 0 {
+        else if place.diningMenus?.count == 0 {
             spinnerView.isHidden = false
             spinnerView.animate()
             view.addSubview(spinnerView)

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -32,7 +32,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             }
             diningHallMenus = diningMenus[menuDay]
             meals = [Meal]()
-            var endTimes = [Int]()
+            var endTimes = [Double]()
             if diningHallMenus.menus.count > 0 {
                 for meal in diningHallMenus.menus {
                     if meal.menu.count != 0 {
@@ -50,7 +50,7 @@ extension PlaceDetailViewController: ListAdapterDataSource {
 
                 // Auto-select next meal if none selected/previous selection unavailable for this day
                 if !meals.contains(selectedMeal) && meals.count > 0 {
-                    let currentTime = Int(Date().timeIntervalSince1970)
+                    let currentTime = Date().timeIntervalSince1970
                     print("Current Time: \(currentTime)")
                     selectedMeal = meals[0]
                     for (index, endTime) in endTimes.enumerated() {
@@ -94,10 +94,10 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         objects.append(SpaceModel(space: Constants.mediumPadding))
         objects.append(SectionDividerModel(lineWidth: dividerHeight))
         objects.append(SpaceModel(space: Constants.mediumPadding))
-        objects.append(MenuHeaderModel())
-        objects.append(SpaceModel(space: Constants.mlPadding))
         switch place.facilityType {
         case .diningHall:
+            objects.append(MenuHeaderModel(showDetails: true))
+            objects.append(SpaceModel(space: Constants.smallPadding))
             objects.append(DaySelectionModel(selectedWeekday: selectedWeekday, weekdays: weekdays))
             objects.append(SpaceModel(space: Constants.smallPadding))
             objects.append(MealFiltersModel(meals: meals, selectedMeal: selectedMeal))
@@ -105,7 +105,10 @@ extension PlaceDetailViewController: ListAdapterDataSource {
             objects.append(SpaceModel(space: Constants.mediumPadding))
             objects.append(MenuModel(diningHallMenu: diningHallMenus, mealNames: meals, selectedMeal: selectedMeal))
         case .cafe:
-            objects.append(MenuModel(cafeMenu: place.cafeMenus!))
+            objects.append(MenuHeaderModel(showDetails: false))
+            objects.append(SpaceModel(space: Constants.smallPadding))
+            let hours = place.hours[0].dailyHours
+            objects.append(MenuModel(cafeMenu: place.cafeMenus!, startTime: hours.startTimestamp, endTime: hours.endTimestamp))
         case .none:
             break
         }

--- a/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController+Extension.swift
@@ -107,8 +107,10 @@ extension PlaceDetailViewController: ListAdapterDataSource {
         case .cafe:
             objects.append(MenuHeaderModel(showDetails: false))
             objects.append(SpaceModel(space: Constants.smallPadding))
-            let hours = place.hours[0].dailyHours
-            objects.append(MenuModel(cafeMenu: place.cafeMenus!, startTime: hours.startTimestamp, endTime: hours.endTimestamp))
+            if !place.hours.isEmpty {
+                let hours = place.hours[0].dailyHours
+                objects.append(MenuModel(cafeMenu: place.cafeMenus!, startTime: hours.startTimestamp, endTime: hours.endTimestamp))
+            }
         case .none:
             break
         }

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -109,7 +109,7 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
             loadingHours = false
             setup()
         }
-        if (place?.menus.weeksMenus)!.isEmpty {
+        if place.diningMenus == nil {
             getMenus()
         } else {
             loadingMenus = false

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -108,7 +108,8 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
             loadingHours = false
             setup()
         }
-        if place.diningMenus == nil {
+        // If facility type is unknown, we haven't fetched any menus yet -- do so now
+        if place.facilityType == nil {
             getMenus()
         } else {
             loadingMenus = false

--- a/Campus Density/Controllers/PlaceDetailViewController.swift
+++ b/Campus Density/Controllers/PlaceDetailViewController.swift
@@ -28,7 +28,6 @@ class PlaceDetailViewController: UIViewController, UIScrollViewDelegate {
     var unavailableLabel: UILabel!
     var selectedWeekday: Int = 0
     var selectedHour: Int = 0
-    var mealList = [Meal]()
     var selectedMeal: Meal = .none
     /// The next days, indexed at the current day and storing (weekday, dayNum) as (0, 5) for Sunday the 5th
     var weekdays = [(Int, Int)]()

--- a/Campus Density/DiningCells/CafeMenuCell.swift
+++ b/Campus Density/DiningCells/CafeMenuCell.swift
@@ -1,0 +1,87 @@
+//
+//  CafeMenuCell.swift
+//  Campus Density
+//
+//  Created by Changyuan Lin on 4/12/21.
+//  Copyright © 2021 Cornell DTI. All rights reserved.
+//
+
+import UIKit
+
+class CafeMenuCell: UICollectionViewCell {
+
+    static let identifier: String = "CafeMenuCell"
+
+    // MARK: - View vars
+    var clockImageView: UIImageView!
+    var hoursLabel: UILabel!
+    var menuLabel: UILabel!
+
+    // MARK: - Constants
+    static let hoursLabelHeight: CGFloat = 22
+    static let clockHoursGap: CGFloat = 8
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setupConstraints() {
+        clockImageView.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.left.equalToSuperview().offset(Constants.smallPadding)
+            make.height.width.equalTo(DiningHallMenuInteriorCell.hoursLabelHeight)
+        }
+        hoursLabel.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.height.equalTo(DiningHallMenuInteriorCell.hoursLabelHeight)
+            make.left.equalTo(clockImageView.snp.right).offset(DiningHallMenuInteriorCell.clockHoursGap)
+        }
+        menuLabel.snp.makeConstraints { make in
+            make.top.equalTo(hoursLabel.snp.bottom).offset(Constants.smallPadding)
+            make.left.equalToSuperview().offset(Constants.smallPadding)
+            make.right.equalToSuperview().offset(-Constants.smallPadding)
+        }
+    }
+
+    func setupViews() {
+        clockImageView = UIImageView()
+        clockImageView.image = UIImage(named: "clock")
+        contentView.addSubview(clockImageView)
+        hoursLabel = UILabel()
+        hoursLabel.font = .sixteenBold
+        hoursLabel.textColor = .black
+        contentView.addSubview(hoursLabel)
+        menuLabel = UILabel()
+        menuLabel.textAlignment = .left
+        menuLabel.numberOfLines = 0
+        menuLabel.isUserInteractionEnabled = true
+        contentView.addSubview(menuLabel)
+    }
+
+    static func getMenuString(cafeMenu: [String]) -> NSMutableAttributedString {
+        return NSMutableAttributedString(
+            string: cafeMenu.joined(separator: "\n"),
+            attributes: [
+                NSAttributedString.Key.foregroundColor: UIColor.warmGray,
+                NSAttributedString.Key.font: UIFont.sixteen,
+                NSAttributedString.Key.paragraphStyle: {
+                    let paragraphStyle = NSMutableParagraphStyle()
+                    paragraphStyle.lineHeightMultiple = 1.15
+                    return paragraphStyle
+                }()
+            ]
+        )
+    }
+
+    func configure(cafeMenu: [String], startTime: Double, endTime: Double) {
+        hoursLabel.text = getHoursString(startTime: startTime, endTime: endTime)
+        menuLabel.attributedText = CafeMenuCell.getMenuString(cafeMenu: cafeMenu)
+        setupConstraints()
+    }
+
+}

--- a/Campus Density/DiningCells/DiningHallMenuCell.swift
+++ b/Campus Density/DiningCells/DiningHallMenuCell.swift
@@ -1,5 +1,5 @@
 //
-//  MenuCell.swift
+//  DiningHallMenuCell.swift
 //  Campus Density
 //
 //  Created by Ashneel Das on 11/10/19.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class MenuCell: UICollectionViewCell {
+class DiningHallMenuCell: UICollectionViewCell {
 
     // MARK: - View vars
     var menuCollectionView: UICollectionView!
@@ -21,7 +21,7 @@ class MenuCell: UICollectionViewCell {
         layout.minimumInteritemSpacing = 0
         layout.minimumLineSpacing = 0
         menuCollectionView = UICollectionView(frame: frame, collectionViewLayout: layout)
-        menuCollectionView.register(MenuInteriorCell.self, forCellWithReuseIdentifier: MenuInteriorCell.identifier)
+        menuCollectionView.register(DiningHallMenuInteriorCell.self, forCellWithReuseIdentifier: DiningHallMenuInteriorCell.identifier)
         menuCollectionView.backgroundColor = .white
         menuCollectionView.isPagingEnabled = true
         menuCollectionView.showsHorizontalScrollIndicator = false

--- a/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
+++ b/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
@@ -110,7 +110,7 @@ class DiningHallMenuInteriorCell: UICollectionViewCell {
     }
 
     func configure(menuData: MenuData) {
-        hoursLabel.text = getHoursString(startTime: Double(menuData.startTime), endTime: Double(menuData.endTime))
+        hoursLabel.text = getHoursString(startTime: menuData.startTime, endTime: menuData.endTime)
         menuLabel.attributedText = DiningHallMenuInteriorCell.getMenuString(menuData: menuData)
         setupConstraints()
     }

--- a/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
+++ b/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
@@ -1,5 +1,5 @@
 //
-//  MenuInteriorCell.swift
+//  DiningHallMenuInteriorCell.swift
 //  Campus Density
 //
 //  Created by Changyuan Lin on 2/29/20.
@@ -8,9 +8,9 @@
 
 import UIKit
 
-class MenuInteriorCell: UICollectionViewCell {
+class DiningHallMenuInteriorCell: UICollectionViewCell {
 
-    static let identifier: String = "MenuInteriorCell"
+    static let identifier: String = "DiningHallMenuInteriorCell"
 
     // MARK: - View vars
     var clockImageView: UIImageView!
@@ -34,12 +34,12 @@ class MenuInteriorCell: UICollectionViewCell {
         clockImageView.snp.makeConstraints { make in
             make.top.equalToSuperview()
             make.left.equalToSuperview().offset(Constants.smallPadding)
-            make.height.width.equalTo(MenuInteriorCell.hoursLabelHeight)
+            make.height.width.equalTo(DiningHallMenuInteriorCell.hoursLabelHeight)
         }
         hoursLabel.snp.makeConstraints { make in
             make.top.equalToSuperview()
-            make.height.equalTo(MenuInteriorCell.hoursLabelHeight)
-            make.left.equalTo(clockImageView.snp.right).offset(MenuInteriorCell.clockHoursGap)
+            make.height.equalTo(DiningHallMenuInteriorCell.hoursLabelHeight)
+            make.left.equalTo(clockImageView.snp.right).offset(DiningHallMenuInteriorCell.clockHoursGap)
         }
         menuLabel.snp.makeConstraints { make in
             make.top.equalTo(hoursLabel.snp.bottom).offset(Constants.smallPadding)
@@ -120,8 +120,8 @@ class MenuInteriorCell: UICollectionViewCell {
     }
 
     func configure(menuData: MenuData) {
-        hoursLabel.text = MenuInteriorCell.getHoursString(menuData: menuData)
-        menuLabel.attributedText = MenuInteriorCell.getMenuString(menuData: menuData)
+        hoursLabel.text = DiningHallMenuInteriorCell.getHoursString(menuData: menuData)
+        menuLabel.attributedText = DiningHallMenuInteriorCell.getMenuString(menuData: menuData)
         setupConstraints()
     }
 

--- a/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
+++ b/Campus Density/DiningCells/DiningHallMenuInteriorCell.swift
@@ -63,16 +63,6 @@ class DiningHallMenuInteriorCell: UICollectionViewCell {
         contentView.addSubview(menuLabel)
     }
 
-    /// Get the hours from `menuData` (specific day and meal) in "Open from <start> - <end>" format
-    static func getHoursString(menuData: MenuData) -> String {
-        let formatter = DateFormatter()
-        formatter.timeZone = TimeZone(identifier: "America/New_York")
-        formatter.timeStyle = .short
-        let startString = formatter.string(from: Date(timeIntervalSince1970: Double(menuData.startTime)))
-        let endString = formatter.string(from: Date(timeIntervalSince1970: Double(menuData.endTime)))
-        return "Open from \(startString) - \(endString)"
-    }
-
     static func getMenuString(menuData: MenuData) -> NSMutableAttributedString {
         let res = NSMutableAttributedString(string: "")
         let newLine = NSAttributedString(string: "\n", attributes: [NSAttributedString.Key.font: UIFont.fourteen])
@@ -89,7 +79,7 @@ class DiningHallMenuInteriorCell: UICollectionViewCell {
             let itemString = NSMutableAttributedString()
             for item in station.items {
                 if itemString != empty {
-                    itemString.append(newLine)
+                    itemString.append(newLine) // the styling is actually overridden here b/c it's part of itemString
                 }
                 itemString.append(NSAttributedString(string: item))
             }
@@ -120,7 +110,7 @@ class DiningHallMenuInteriorCell: UICollectionViewCell {
     }
 
     func configure(menuData: MenuData) {
-        hoursLabel.text = DiningHallMenuInteriorCell.getHoursString(menuData: menuData)
+        hoursLabel.text = getHoursString(startTime: Double(menuData.startTime), endTime: Double(menuData.endTime))
         menuLabel.attributedText = DiningHallMenuInteriorCell.getMenuString(menuData: menuData)
         setupConstraints()
     }

--- a/Campus Density/DiningCells/MenuHeaderCell.swift
+++ b/Campus Density/DiningCells/MenuHeaderCell.swift
@@ -58,6 +58,10 @@ class MenuHeaderCell: UICollectionViewCell {
         }
     }
 
+    func configure(showDetails: Bool) {
+        detailsLabel.isHidden = !showDetails
+    }
+
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Campus Density/DiningModels/MenuHeaderModel.swift
+++ b/Campus Density/DiningModels/MenuHeaderModel.swift
@@ -10,7 +10,12 @@ import Foundation
 import IGListKit
 
 class MenuHeaderModel {
+    let showDetails: Bool
     let identifier = UUID().uuidString
+
+    init(showDetails: Bool) {
+        self.showDetails = showDetails
+    }
 }
 
 extension MenuHeaderModel: ListDiffable {

--- a/Campus Density/DiningModels/MenuModel.swift
+++ b/Campus Density/DiningModels/MenuModel.swift
@@ -12,10 +12,17 @@ import IGListKit
 class MenuModel {
 
     let facilityType: FacilityType
-    let diningHallMenu: DayMenus! // nil if facilityType == .cafe
-    let mealNames: [Meal]! // nil if facilityType == .cafe
+
+    // .diningHall
+    let diningHallMenu: DayMenus!
+    let mealNames: [Meal]!
     let selectedMeal: Meal
-    let cafeMenu: [String]! // nil if facilityType == .diningHall
+
+    // .cafe
+    let cafeMenu: [String]!
+    let cafeStartTime: Double!
+    let cafeEndTime: Double!
+
     let identifier = UUID().uuidString
 
     init(diningHallMenu: DayMenus, mealNames: [Meal], selectedMeal: Meal) {
@@ -24,14 +31,18 @@ class MenuModel {
         self.mealNames = mealNames
         self.selectedMeal = selectedMeal
         self.cafeMenu = nil
+        self.cafeStartTime = nil
+        self.cafeEndTime = nil
     }
 
-    init(cafeMenu: [String]) {
+    init(cafeMenu: [String], startTime: Double, endTime: Double) {
         self.facilityType = .cafe
         self.diningHallMenu = nil
         self.mealNames = nil
         self.selectedMeal = .none
         self.cafeMenu = cafeMenu
+        self.cafeStartTime = startTime
+        self.cafeEndTime = endTime
     }
 
 }

--- a/Campus Density/DiningModels/MenuModel.swift
+++ b/Campus Density/DiningModels/MenuModel.swift
@@ -11,15 +11,27 @@ import IGListKit
 
 class MenuModel {
 
-    var menu: DayMenus
-    var mealNames: [Meal]
-    var selectedMeal: Meal
+    let facilityType: FacilityType
+    let diningHallMenu: DayMenus! // nil if facilityType == .cafe
+    let mealNames: [Meal]! // nil if facilityType == .cafe
+    let selectedMeal: Meal
+    let cafeMenu: [String]! // nil if facilityType == .diningHall
     let identifier = UUID().uuidString
 
-    init(menu: DayMenus, mealNames: [Meal], selectedMeal: Meal) {
-        self.menu = menu
+    init(diningHallMenu: DayMenus, mealNames: [Meal], selectedMeal: Meal) {
+        self.facilityType = .diningHall
+        self.diningHallMenu = diningHallMenu
         self.mealNames = mealNames
         self.selectedMeal = selectedMeal
+        self.cafeMenu = nil
+    }
+
+    init(cafeMenu: [String]) {
+        self.facilityType = .cafe
+        self.diningHallMenu = nil
+        self.mealNames = nil
+        self.selectedMeal = .none
+        self.cafeMenu = cafeMenu
     }
 
 }

--- a/Campus Density/SectionControllers/MenuHeaderSectionController.swift
+++ b/Campus Density/SectionControllers/MenuHeaderSectionController.swift
@@ -15,7 +15,9 @@ class MenuHeaderSectionController: ListSectionController {
     var menuHeaderModel: MenuHeaderModel!
 
     // MARK: - Constants
-    let headerText = "Menu"
+    let headerLabelText = "Menus & Hours"
+    let detailsLabelText = "Show Details For:"
+    let spacing: CGFloat = 5
 
     init(menuHeaderModel: MenuHeaderModel) {
         self.menuHeaderModel = menuHeaderModel
@@ -23,12 +25,16 @@ class MenuHeaderSectionController: ListSectionController {
 
     override func sizeForItem(at index: Int) -> CGSize {
         guard let containerSize = collectionContext?.containerSize else { return .zero }
-        let textHeight = headerText.height(withConstrainedWidth: containerSize.width - Constants.smallPadding * 2, font: .thirtyBold)
+        var textHeight = headerLabelText.height(withConstrainedWidth: containerSize.width - Constants.smallPadding * 2, font: .twentyFiveBold)
+        if menuHeaderModel.showDetails {
+            textHeight += detailsLabelText.height(withConstrainedWidth: containerSize.width - Constants.smallPadding * 2, font: .sixteen) + spacing
+        }
         return CGSize(width: containerSize.width, height: textHeight)
     }
 
     override func cellForItem(at index: Int) -> UICollectionViewCell {
         let cell = collectionContext?.dequeueReusableCell(of: MenuHeaderCell.self, for: self, at: index) as! MenuHeaderCell
+        cell.configure(showDetails: menuHeaderModel.showDetails)
         return cell
     }
 

--- a/Campus Density/SectionControllers/MenuSectionController.swift
+++ b/Campus Density/SectionControllers/MenuSectionController.swift
@@ -84,7 +84,7 @@ class MenuSectionController: ListSectionController {
             return cell
         case .cafe:
             let cell = collectionContext?.dequeueReusableCell(of: CafeMenuCell.self, for: self, at: index) as! CafeMenuCell
-            cell.configure(cafeMenu: menuModel.cafeMenu, startTime: 0, endTime: 1000)
+            cell.configure(cafeMenu: menuModel.cafeMenu, startTime: menuModel.cafeStartTime, endTime: menuModel.cafeEndTime)
             return cell
         }
     }
@@ -96,7 +96,7 @@ class MenuSectionController: ListSectionController {
 
 }
 
-// For the collection view inside the menu cell, returning interior cells
+// For the collection view inside the dining hall menu cell, returning dining hall interior cells
 extension MenuSectionController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return menuModel.mealNames.count

--- a/Campus Density/Utils.swift
+++ b/Campus Density/Utils.swift
@@ -25,6 +25,16 @@ func getHourLabel(selectedHour: Int) -> String {
     return "\(hour) \(selectedHour < 12 ? "AM" : "PM")"
 }
 
+/// Get open hours in "Open from <start> - <end>" format, in the Ithaca time zone
+func getHoursString(startTime: Double, endTime: Double) -> String {
+    let formatter = DateFormatter()
+    formatter.timeZone = TimeZone(identifier: "America/New_York")
+    formatter.timeStyle = .short
+    let startString = formatter.string(from: Date(timeIntervalSince1970: startTime))
+    let endString = formatter.string(from: Date(timeIntervalSince1970: endTime))
+    return "Open from \(startString) - \(endString)"
+}
+
 func getCurrentDensity(densityMap: [Int: Double], selectedHour: Int) -> String {
     if densityMap.isEmpty {
         return "Closed"


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request implements cafe menus. The function for getting menu data decodes the facility type and switches decoding weeksMenus into cafeMenus or diningHallMenus (necessary as a 2-step process since cafe menus and dining hall menus have different structures). The MenuModel and MenuSectionController have been changed to handle the case when the facility is a cafe in addition to a dining hall. When supplying a cell the MenuSectionController returns a DiningHallMenuCell or a CafeMenuCell. The PlaceDetailSectionController extension changes what models are returned in objects(), only including menu filters and day chips when the place is a dining hall.

In addition, the cafe menus use data from the place hours at index 0 (today) to get the hours string at the top of the menu, where for dining hall menus it is part of the original menu data. The menu header is also differentiated to show the text "Show Details For:" or not depending on the facility type. The cell size has also been corrected so there is no clipping when the padding between cells is too small (this also changes depending on if the subtitle is shown or not). Some small improvements to objects() code handling the dining hall case, adding a guard statement. Also remove some unnecessary nesting for dining hall menus. Moved a function into Utils.

- [x] updated api func to handle cafe and dining hall menus
- [x] implemented cafe menus cell
- [x] some code quality improvements

### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

![Screen Shot 2021-04-13 at 21 16 00](https://user-images.githubusercontent.com/22627336/114643522-d0b42000-9ca3-11eb-86da-bf4998c60436.png)
![Screen Shot 2021-04-13 at 21 15 53](https://user-images.githubusercontent.com/22627336/114643525-d14cb680-9ca3-11eb-83df-06e75cc378b7.png)

The spinner is still present before menus are fully loaded, and disappears when expected. Switching to a day with no dining hall menus and back works as expected.

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

For the MenuHeaderCell, an alternative is to split the cell into two cells, only including the one with the detail text when displaying dining hall style menus. This removes the need for the header model to carry a boolean if it should show the detail text or not. However sometimes this is taken too far and the app has way too many tiny cells.

